### PR TITLE
Create terraform.tf

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "c19-courts-terraform-state"
+    key = "terraform.tfstate"
+    region = "eu-west-2"
+  }
+}


### PR DESCRIPTION
## Related Issue
#19 

## Description
Add a terraform.tf file to ensure that Terraform uses a remote S3 bucket for storing of its state, allowing the team to share one single state.

## Requested Reviewers
@nicanor-jay @riaz1751 @lenaverse @cameronriley0 

## Additional Information
The remote endpoint (S3 bucket) must be made manually - there is no proper way to integrate it into the Terraform workflow (as far as I can tell).
