### PR TITLE
Add ECR Dashboard creation to Terraform phase one

### DIFF
--- a/terraform/phase-one/main.tf
+++ b/terraform/phase-one/main.tf
@@ -35,3 +35,9 @@ resource "aws_ecr_repository" "ecs-ecr" {
   name                 = "c19-courts-ecs-task"
   image_tag_mutability = "MUTABLE"
 }
+
+# ECR to host the ECS Dashboard
+resource "aws_ecr_repository" "dashboard-ecr" {
+  name                 = "c19-courts-dashboard-service"
+  image_tag_mutability = "MUTABLE"
+}


### PR DESCRIPTION
## Related Issue
#62 

## Description
Creates the ECR used to hold the dashboard image (added to phase-one main.tf)
Closes #62.

## Requested Reviewers
@arbeh0 @cameronriley0 @lenaverse @riaz1751 

## Additional Information
N/A
