### PR TITLE
Terraform security group for RDS instance

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -26,6 +26,7 @@ REGION = "your_aws_region"
 DB_NAME = "your_db_name"
 DB_USERNAME = "your_db_username"
 DB_PASSWORD = "your_db_password"
+VPC_ID = "your_vpc_id"
 SUBNET_IDS = "[list_of_subnet_ids]"
 ```
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,6 +6,7 @@ module "phase-one" {
     DB_NAME = var.DB_NAME
     DB_USERNAME = var.DB_USERNAME
     DB_PASSWORD = var.DB_PASSWORD
+    VPC_ID = var.VPC_ID
     SUBNET_IDS = var.SUBNET_IDS
 }
 
@@ -17,5 +18,6 @@ module "phase-two" {
     DB_NAME = var.DB_NAME
     DB_USERNAME = var.DB_USERNAME
     DB_PASSWORD = var.DB_PASSWORD
+    VPC_ID = var.VPC_ID
     SUBNET_IDS = var.SUBNET_IDS
 }

--- a/terraform/phase-one/main.tf
+++ b/terraform/phase-one/main.tf
@@ -8,6 +8,21 @@ resource "aws_db_subnet_group" "c19_courts_db_subnet_group" {
   }
 }
 
+# Security group
+resource "aws_security_group" "courts_security_group" {
+    name = "c19-courts-sg"
+    description = "Allow inbound traffic to an RDS instance"
+    vpc_id = var.VPC_ID
+
+    ingress {
+        description = "Postgres access from the internet"
+        from_port = 5432
+        to_port = 5432
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
 # DB instance
 resource "aws_db_instance" "c19_courts_db" {
   identifier        = "c19-courts-db"
@@ -19,6 +34,7 @@ resource "aws_db_instance" "c19_courts_db" {
   username  = var.DB_USERNAME
   password  = var.DB_PASSWORD
 
+  vpc_security_group_ids = [aws_security_group.courts_security_group.id]
   db_subnet_group_name = aws_db_subnet_group.c19_courts_db_subnet_group.name
   publicly_accessible  = true
   skip_final_snapshot  = true

--- a/terraform/phase-one/variables.tf
+++ b/terraform/phase-one/variables.tf
@@ -29,6 +29,11 @@ variable "DB_PASSWORD" {
   sensitive   = true
 }
 
+variable "VPC_ID" {
+  description = "VPC ID for the RDS instance"
+  type = string
+}
+
 variable "SUBNET_IDS" {
   description = "List of subnet IDs for the DB subnet group"
   type        = list(string)

--- a/terraform/phase-two/variables.tf
+++ b/terraform/phase-two/variables.tf
@@ -29,6 +29,11 @@ variable "DB_PASSWORD" {
   sensitive   = true
 }
 
+variable "VPC_ID" {
+  description = "VPC ID for the RDS instance"
+  type = string
+}
+
 variable "SUBNET_IDS" {
   description = "List of subnet IDs for the DB subnet group"
   type        = list(string)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,6 +29,11 @@ variable "DB_PASSWORD" {
   sensitive   = true
 }
 
+variable "VPC_ID" {
+  description = "VPC ID for the RDS instance"
+  type = string
+}
+
 variable "SUBNET_IDS" {
   description = "List of subnet IDs for the DB subnet group"
   type        = list(string)


### PR DESCRIPTION
## Related Issue
#57 

## Description
Added terraform code to create a custom security group for our RDS instance. I also had to add the c19 VPC ID as a new variable to all the `variables.tf` files, as well as to `main.tf` in our root terraform directory. Because the value of this variable is stored in `terraform.tfvars` I also updated the README.

Closes #57 .

## Requested Reviewers
Anyone available.

## Additional Information
**Make sure you add the new variable to `terraform.tfvars` in this format:**
```
VPC_ID = "your_vpc_id"
```
For us this would be the c19-vpc (I will share the ID on slack).
