### PR TITLE
Initialise dashboard

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:latest
+
+WORKDIR dashboard
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY charts.py dashboard.py data_cache.py rds_utils.py utils.py ./
+
+CMD ["streamlit", "run", "dashboard.py", "--server.port", "8501"]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,26 @@
+# Dashboard
+
+This folder contains all the python scripts used to create and run the Courts Transcripts Dashboard, as well as a helper `build_push_dockerfile.sh` to build and upload the image to AWS ECR.
+
+## Requirements
+1. A root level `.env` file formatted as stated in the [project level readme](../README.md).
+
+
+## Usage
+
+### Locally
+Run the dashboard locally with
+```bash
+streamlit run dashboard.py
+```
+### AWS Hosted
+
+Provided that you have filled out the project level `.env` file as specified, you can also make use of `build_push_dockerfile.sh` by
+
+```bash
+bash build_push_dockerfile.sh
+```
+
+Which automatically builds and pushes your dashboard image up to the specified ECR Repository on AWS.
+
+Once the image is hosted on the ECR Repository, and you have completed all other steps for terraform stage two, running the stage two instructions will create a task definition for the dashboard, as well as begin hosting it as an ECS Fargate Service.

--- a/dashboard/build_push_dockerfile.sh
+++ b/dashboard/build_push_dockerfile.sh
@@ -1,0 +1,9 @@
+source ../.env
+
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+docker buildx build . -t $APP_NAME:latest --platform "Linux/amd64"
+
+docker tag $APP_NAME:latest $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$DASHBOARD_ECR_NAME:latest
+
+docker push $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$DASHBOARD_ECR_NAME:latest

--- a/dashboard/charts.py
+++ b/dashboard/charts.py
@@ -1,0 +1,6 @@
+""" 
+Functions to take in DataFrame as argument and returns an Altair chart
+for usage on the Streamlit dashboard.
+"""
+import altair as alt
+from pandas import DataFrame

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -1,0 +1,12 @@
+"""Entry dashboard page"""
+
+import logging
+import streamlit as st
+from dotenv import load_dotenv
+from utils import setup_logging
+
+load_dotenv()
+setup_logging()
+
+logging.info("Running dashboard.")
+st.title('Court Transcript Dashboard')

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -10,3 +10,9 @@ setup_logging()
 
 logging.info("Running dashboard.")
 st.title('Court Transcript Dashboard')
+
+col1, col2, col3 = st.columns(3)
+
+with col1:
+    # Placeholder until RDS is live
+    st.metric("Total Court Hearings", 100, border=True)

--- a/dashboard/data_cache.py
+++ b/dashboard/data_cache.py
@@ -1,0 +1,17 @@
+"""File holding functions which retrieve data from the RDS (which can be cached)."""
+from psycopg2.extensions import connection
+import streamlit as st
+import pandas as pd
+from rds_utils import query_rds
+
+
+@st.cache_data(ttl=600)  # cache for 10 min
+def get_total_hearing_count(con: connection) -> pd.DataFrame:
+    """Gets total court hearing count."""
+    query = """
+    SELECT
+        COUNT(*)
+    FROM
+        hearing;
+    """
+    return query_rds(con, query)

--- a/dashboard/rds_utils.py
+++ b/dashboard/rds_utils.py
@@ -1,0 +1,55 @@
+"""File holding RDS Utility functions"""
+
+import logging
+from os import environ as ENV
+from psycopg2.extensions import connection
+from psycopg2 import connect, Error
+from psycopg2.extras import RealDictCursor
+from dotenv import load_dotenv
+import pandas as pd
+
+
+def get_db_connection():
+    """Gets the db connection and returns it."""
+    try:
+        con = connect(
+            host=ENV["DB_HOST"],
+            database=ENV["DB_NAME"],
+            user=ENV["DB_USERNAME"],
+            password=ENV["DB_PASSWORD"],
+            port=ENV["DB_PORT"],
+            cursor_factory=RealDictCursor,
+        )
+        logging.info("Connected to RDS.")
+        return con
+    except Error as e:
+        print(f"Error connecting to database: {e}")
+        logging.critical("Error connecting to RDS")
+        return None
+
+
+def query_rds(con: connection, query: str) -> pd.DataFrame:
+    """Function to query the RDS with a given query."""
+    df = pd.read_sql(query, con)
+    return df
+
+
+def get_total_hearing_count(con: connection) -> pd.DataFrame:
+    """Gets total court hearing count."""
+    query = """
+    SELECT
+        COUNT(*)
+    FROM
+        hearing;
+    """
+    return query_rds(con, query)
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    conn = get_db_connection()
+
+    print(query_rds(conn, "select * from information_schema.tables"))
+    print(get_total_hearing_count(conn))
+
+    conn.close()

--- a/dashboard/rds_utils.py
+++ b/dashboard/rds_utils.py
@@ -32,24 +32,3 @@ def query_rds(con: connection, query: str) -> pd.DataFrame:
     """Function to query the RDS with a given query."""
     df = pd.read_sql(query, con)
     return df
-
-
-def get_total_hearing_count(con: connection) -> pd.DataFrame:
-    """Gets total court hearing count."""
-    query = """
-    SELECT
-        COUNT(*)
-    FROM
-        hearing;
-    """
-    return query_rds(con, query)
-
-
-if __name__ == "__main__":
-    load_dotenv()
-    conn = get_db_connection()
-
-    print(query_rds(conn, "select * from information_schema.tables"))
-    print(get_total_hearing_count(conn))
-
-    conn.close()

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+pylint
+pytest
+altair
+pandas

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -3,3 +3,5 @@ pylint
 pytest
 altair
 pandas
+python-dotenv
+psycopg2-binary

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -1,0 +1,9 @@
+"""Util functions."""
+import logging
+
+
+def setup_logging() -> None:
+    """Configure logging output."""
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.info("Logging initialised.")


### PR DESCRIPTION
## Related Issue
Closes #67 

## Description
This PR
- Updates project README with more env vars needed in the dashboard folder.
- Updates project README with context on terraform phases and when to run them (can be improved down the line)
- Updates dashboard README with more detail.
- Adds initial scripts for dashboard to work.
- Adds `build_push_dockerfile.sh` helper bash script to push updates to image on ECR.
- Adds a Dockerfile in the dashboard folder to dockerise the initial dashboard.

## Requested Reviewers
@lenaverse 

## Additional Information
No testing applicable as of yet, as functions aren't pure & it is a skeleton of the final dashboard.
