### PR TITLE
Add XML metadata extraction script

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -1,5 +1,6 @@
 # Contents
-1. `parse_xml.py`
+1. [`parse_xml.py`](#parse_xmlpy)
+2. [`metadata_xml.py`](#metadata_xmlpy)
 
 ## `parse_xml.py`
 
@@ -12,7 +13,7 @@ This script is intended to be imported as a module by other scripts (it has no "
 ```python
 """ Your module. """
 
-from parse_xml.py import get_label_text_dict
+from parse_xml import get_label_text_dict
 
 ...
 ```
@@ -22,3 +23,47 @@ This method will take a filepath to an `.xml` file, and return a `{label:text}` 
 - `text` is the raw text under that heading
 
 Note that two special headings may be added - `DOC_START` and `DOC_END` - for raw text which does not have a heading at the head/tail of the XML file.
+
+## `metadata_xml.py`
+
+A script which will extract metadata contained in a XML court transcript from the [National Archives](https://caselaw.nationalarchives.gov.uk/).
+
+### Use
+
+This script is intended to be imported as a module by other scripts - however, it can also be used standalone.
+
+#### As a module
+
+For use as a module, import like so:
+
+```python
+""" Your module. """
+
+from metadata_xml import get_metadata
+
+...
+```
+
+`get_metadata()` takes a filepath to an `.xml` file, and returns a dictionary containing metadata about that file.
+
+Specifically, the data returned is:
+- `title` (`str`): The title of the hearing.
+- `citation` (`str`): Neutral citation; can be used as unique identifier.
+- `verdict_date` (`datetime`): The date when judgement was handed down.
+- `court` (`str`): The name of the court where the hearing took place.
+- `url` (`str`): A URL to the hearing transcript page.
+
+#### As a script
+
+For use as a script, you must call the script like so:
+
+```bash
+$ python metadata_xml.py -f <filename.xml>
+```
+
+The script accepts two CLI arguments:
+
+- `-f`: path to XML file to extract from; mandatory.
+- `-o`: a flag to indicate if metadata should be output as JSON.
+
+You can also call the script with `-h` to view a summary of the arguments listed above.

--- a/pipeline/conftest.py
+++ b/pipeline/conftest.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+##### XML PARSER CONSTANTS ####
+
 XML_TEMPLATE = """
 <akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0">
 <judgment name="judgment">
@@ -48,6 +50,70 @@ SUB_NON_HEADING = """
 <p class="ParaApprovedLevel2">Whether the payments by Mr</p>
 </content>
 </subparagraph>
+"""
+
+##### XML METADATA CONSTANTS #####
+
+XML_METADATA = """
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+<judgment name="judgment">
+<meta>
+<identification source="#tna">
+<FRBRWork>
+<FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/ukpc/2025/47"/>
+<FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/ukpc/2025/47"/>
+<FRBRdate date="2025-09-30" name="judgment"/>
+<FRBRauthor href="#ukpc"/>
+<FRBRcountry value="GB-UKM"/>
+<FRBRnumber value="47"/>
+<FRBRname value="Fang Ankong and another v Green Elite Ltd  (Virgin Islands)"/>
+</FRBRWork>
+<FRBRExpression>
+<FRBRthis value="https://caselaw.nationalarchives.gov.uk/ukpc/2025/47"/>
+<FRBRuri value="https://caselaw.nationalarchives.gov.uk/ukpc/2025/47"/>
+<FRBRdate date="2025-09-30" name="judgment"/>
+<FRBRauthor href="#ukpc"/>
+<FRBRlanguage language="eng"/>
+</FRBRExpression>
+<FRBRManifestation>
+<FRBRthis value="https://caselaw.nationalarchives.gov.uk/ukpc/2025/47/data.xml"/>
+<FRBRuri value="https://caselaw.nationalarchives.gov.uk/ukpc/2025/47/data.xml"/>
+<FRBRdate date="2025-09-30T10:06:38" name="transform"/>
+<FRBRdate date="2025-09-30T11:02:41" name="tna-enriched"/>
+<FRBRauthor href="#tna"/>
+<FRBRformat value="application/xml"/>
+</FRBRManifestation>
+</identification>
+<lifecycle source="#">
+<eventRef date="2025-09-30" refersTo="#judgment" source="#"/>
+</lifecycle>
+<references source="#tna">
+<TLCOrganization eId="ukpc" href="https://www.jcpc.uk/" showAs="The Judicial Committee of the Privy Council"/>
+<TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives"/>
+<TLCEvent eId="judgment" href="#" showAs="judgment"/>
+<TLCPerson eId="fang-ankong-and-another" href="" showAs="Fang Ankong and another"/>
+<TLCPerson eId="green-elite-ltd" href="" showAs="Green Elite Ltd"/>
+<TLCRole eId="appellant" href="" showAs="Appellant"/>
+<TLCRole eId="respondent" href="" showAs="Respondent"/>
+<TLCPerson eId="judge-lord-briggs" href="/judge-lord-briggs" showAs="Lord Briggs"/>
+<TLCPerson eId="judge-lord-sales" href="/judge-lord-sales" showAs="Lord Sales"/>
+<TLCPerson eId="judge-lord-hamblen" href="/judge-lord-hamblen" showAs="Lord Hamblen"/>
+<TLCPerson eId="judge-lord-burrows" href="/judge-lord-burrows" showAs="Lord Burrows"/>
+<TLCPerson eId="judge-lord-richards" href="/judge-lord-richards" showAs="Lord Richards"/>
+</references>
+<proprietary source="#">
+<uk:court>UKPC</uk:court>
+<uk:year>2025</uk:year>
+<uk:number>47</uk:number>
+<uk:cite>[2025] UKPC 47</uk:cite>
+<uk:parser>0.27.1</uk:parser>
+<uk:hash>eba479a0f0ba3086f270d4fbc7c8a6d15a17a8f883e57a891ef10db0a281210e</uk:hash>
+<uk:jurisdiction/>
+<uk:tna-enrichment-engine>7.4.0</uk:tna-enrichment-engine>
+</proprietary>
+</meta>
+</judgment>
+</akomaNtoso>
 """
 
 
@@ -97,3 +163,9 @@ def xml_reverse_order() -> bytes:
         LEVEL_STYLE_HEADING,
         LEVEL_NON_HEADING
     ).encode("utf-8")
+
+
+@pytest.fixture
+def xml_metadata() -> bytes:
+    """Returns XML string with only metadata component."""
+    return XML_METADATA.encode("utf-8")

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -1,5 +1,7 @@
 """Extract metadata from hearing transcripts."""
 
+from datetime import datetime
+
 from lxml import etree
 
 # Common namespaces for XML files from https://caselaw.nationalarchives.gov.uk/
@@ -16,11 +18,12 @@ def get_case_url(meta: "etree._Element") -> str:
     return url_element.get("value")
 
 
-def get_case_judgement_date(meta: "etree._Element") -> str:
+def get_case_judgement_date(meta: "etree._Element") -> datetime:
     """Returns the date when judgement was handed down from metadata."""
     xpath = "//n:FRBRExpression//n:FRBRdate"
     date_element = meta.xpath(xpath, namespaces=NS_MAPPING)[0]
-    return date_element.get("date")
+    date_str = date_element.get("date")
+    return datetime.strptime(date_str, "%Y-%m-%d")
 
 
 def get_case_citation(meta: "etree._Element") -> str:

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -2,9 +2,55 @@
 
 from lxml import etree
 
-# Common namespace for XML files from https://caselaw.nationalarchives.gov.uk/
-NAMESPACE = "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}"
+# Common namespaces for XML files from https://caselaw.nationalarchives.gov.uk/
+NS_MAPPING = {
+    "n": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
+    "nuk": "https://caselaw.nationalarchives.gov.uk/akn"
+}
+
+
+def get_case_url(meta: "etree._Element") -> str:
+    """Returns case hearing URL from metadata."""
+    xpath = "//n:FRBRExpression//n:FRBRthis"
+    url_element = meta.xpath(xpath, namespaces=NS_MAPPING)[0]
+    return url_element.get("value")
+
+
+def get_case_judgement_data(meta: "etree._Element") -> str:
+    """Returns the date when judgement was handed down from metadata."""
+    xpath = "//n:FRBRExpression//n:FRBRdate"
+    date_element = meta.xpath(xpath, namespaces=NS_MAPPING)[0]
+    return date_element.get("date")
+
+
+def get_case_citation(meta: "etree._Element") -> str:
+    """Returns the neutral citation, which can be used as a unique identifier."""
+    xpath = "//nuk:cite"
+    cite_element = meta.xpath(xpath, namespaces=NS_MAPPING)[0]
+    return cite_element.text
+
+
+def get_case_name(meta: "etree._Element") -> str:
+    """Returns the title given to the case hearing."""
+    xpath = "//n:FRBRWork//n:FRBRname"
+    name_element = meta.xpath(xpath, namespaces=NS_MAPPING)[0]
+    return name_element.get("value")
+
+
+def get_court_name(meta: "etree._Element") -> str:
+    """Returns the name of the institution/court where the hearing took place."""
+    xpath = "//n:TLCOrganization"
+    org_element = meta.xpath(xpath, namespaces=NS_MAPPING)
+    # tnc (The National Archives) is also listed as an org, so we need to filter it
+    org_element = list(filter(lambda e: e.get("eId") != "tna", org_element))[0]
+    return org_element.get("showAs")
+
 
 if __name__ == "__main__":
     root = etree.parse("xmls/data_1.xml")
-    meta = list(root.iter(NAMESPACE + "meta"))[0]
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    url = get_case_url(meta)
+    date = get_case_judgement_data(meta)
+    cite = get_case_citation(meta)
+    name = get_case_name(meta)
+    court_name = get_court_name(meta)

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -44,7 +44,7 @@ def get_court_name(meta: "etree._Element") -> str:
     """Returns the name of the institution/court where the hearing took place."""
     xpath = "//n:TLCOrganization"
     org_element = meta.xpath(xpath, namespaces=NS_MAPPING)
-    # tnc (The National Archives) is also listed as an org, so we need to filter it
+    # tna (The National Archives) is also listed as an org, so we need to filter it
     org_element = list(filter(lambda e: e.get("eId") != "tna", org_element))[0]
     return org_element.get("showAs")
 

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -1,0 +1,10 @@
+"""Extract metadata from hearing transcripts."""
+
+from lxml import etree
+
+# Common namespace for XML files from https://caselaw.nationalarchives.gov.uk/
+NAMESPACE = "{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}"
+
+if __name__ == "__main__":
+    root = etree.parse("xmls/data_1.xml")
+    meta = list(root.iter(NAMESPACE + "meta"))[0]

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -16,7 +16,7 @@ def get_case_url(meta: "etree._Element") -> str:
     return url_element.get("value")
 
 
-def get_case_judgement_data(meta: "etree._Element") -> str:
+def get_case_judgement_date(meta: "etree._Element") -> str:
     """Returns the date when judgement was handed down from metadata."""
     xpath = "//n:FRBRExpression//n:FRBRdate"
     date_element = meta.xpath(xpath, namespaces=NS_MAPPING)[0]
@@ -46,11 +46,33 @@ def get_court_name(meta: "etree._Element") -> str:
     return org_element.get("showAs")
 
 
-if __name__ == "__main__":
-    root = etree.parse("xmls/data_1.xml")
+def get_metadata(filename: str) -> dict:
+    """
+    Extracts metadata from `filename` and returns it as a dictionary.
+    Structure of the returned dictionary:
+
+    `title` (`str`): The title of the hearing.
+    `citation` (`str`): Neutral citation; can be used as unique identifier.
+    `verdict_date` (`datetime`): The date when judgement was handed down.
+    `court` (`str`): The name of the court where the hearing took place.
+    `url` (`str`): A URL to the hearing transcript page.
+    """
+    if not filename.endswith(".xml"):
+        raise ValueError("filename must be a .xml file")
+
+    root = etree.parse(filename)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
-    url = get_case_url(meta)
-    date = get_case_judgement_data(meta)
-    cite = get_case_citation(meta)
-    name = get_case_name(meta)
-    court_name = get_court_name(meta)
+
+    metadata = {
+        "title": get_case_name(meta),
+        "citation": get_case_citation(meta),
+        "verdict_date": get_case_judgement_date(meta),
+        "court": get_court_name(meta),
+        "url": get_case_url(meta)
+    }
+
+    return metadata
+
+
+if __name__ == "__main__":
+    data = get_metadata("xmls/data_1.xml")

--- a/pipeline/test_metadata_xml.py
+++ b/pipeline/test_metadata_xml.py
@@ -1,0 +1,111 @@
+# pylint: skip-file
+
+from unittest.mock import Mock
+from datetime import datetime
+
+import pytest
+from lxml import etree
+
+from metadata_xml import (
+    NS_MAPPING,
+    get_case_name,
+    get_case_citation,
+    get_case_judgement_date,
+    get_court_name,
+    get_case_url,
+    get_metadata
+)
+
+
+def test_get_case_name_correct_type(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    name = get_case_name(meta)
+    assert isinstance(name, str)
+
+
+def test_get_case_name_correct_name(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    name = get_case_name(meta)
+    real_name = "Fang Ankong and another v Green Elite Ltd  (Virgin Islands)"
+    assert name == real_name
+
+
+def test_get_case_citation_correct_type(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    citation = get_case_citation(meta)
+    assert isinstance(citation, str)
+
+
+def test_get_case_citation_correct_citation(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    citation = get_case_citation(meta)
+    real_citation = "[2025] UKPC 47"
+    assert citation == real_citation
+
+
+def test_get_case_judgement_date_correct_type(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    date = get_case_judgement_date(meta)
+    assert isinstance(date, datetime)
+
+
+def test_get_case_judgement_date_correct_citation(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    date = get_case_judgement_date(meta)
+    real_date = datetime(year=2025, month=9, day=30)
+    assert date == real_date
+
+
+def test_get_court_name_correct_type(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    court_name = get_court_name(meta)
+    assert isinstance(court_name, str)
+
+
+def test_get_court_name_correct_name(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    court_name = get_court_name(meta)
+    real_court_name = "The Judicial Committee of the Privy Council"
+    assert court_name == real_court_name
+
+
+def test_get_case_url_correct_type(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    url = get_case_url(meta)
+    assert isinstance(url, str)
+
+
+def test_get_case_url_correct_name(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    url = get_case_url(meta)
+    real_url = "https://caselaw.nationalarchives.gov.uk/ukpc/2025/47"
+    assert url == real_url
+
+
+def test_get_metadata_rejects_bad_filename():
+    with pytest.raises(ValueError) as exc_info:
+        get_metadata("bad_file.csv")
+        assert "filename must be a .xml file" in exc_info.value
+
+
+def test_get_metadata_returns_dict(xml_metadata):
+    etree.parse = Mock(return_value=etree.fromstring(xml_metadata))
+    metadata = get_metadata("dummy.xml")
+    assert isinstance(metadata, dict)
+
+
+def test_get_metadata_dict_has_correct_keys(xml_metadata):
+    etree.parse = Mock(return_value=etree.fromstring(xml_metadata))
+    metadata = get_metadata("dummy.xml")
+    assert list(metadata.keys()) == ['title', 'citation',
+                                     'verdict_date', 'court', 'url']


### PR DESCRIPTION
## Related Issue
Closes #73 

## Description
This PR adds a script - `metadata_xml.py` - which can extract useful information from XML court transcript files, and return this as a dictionary, or output it to a JSON file.

This PR also adds a test suite for the new script, and updates the README with details on its use. 

## Requested Reviewers
Anyone

## Additional Information
N/A
