### PR TITLE
Terraform ESC task definition (dashboard)

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -18,7 +18,7 @@ terraform {
 }
 ```
 
-Make sure to add a `terraform.tfvars` file in this folder with your AWS access key, AWS secret access key, DB password and DB subnet IDs in this format:
+Make sure to add a `terraform.tfvars` file in this folder with this format:
 ```
 ACCESS_KEY = "your_aws_access_key"
 SECRET_ACCESS_KEY = "your_aws_secret_key"
@@ -28,6 +28,8 @@ DB_USERNAME = "your_db_username"
 DB_PASSWORD = "your_db_password"
 VPC_ID = "your_vpc_id"
 SUBNET_IDS = "[list_of_subnet_ids]"
+DASHBOARD_IMAGE_URI = "your_dashboard_image_uri"
+RDS_ENDPOINT = "your_rds_endpoint"
 ```
 
 ## 🚀 How to run

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,4 +20,6 @@ module "phase-two" {
     DB_PASSWORD = var.DB_PASSWORD
     VPC_ID = var.VPC_ID
     SUBNET_IDS = var.SUBNET_IDS
+    RDS_ENDPOINT = var.RDS_ENDPOINT
+    DASHBOARD_IMAGE_URI = var.DASHBOARD_IMAGE_URI
 }

--- a/terraform/phase-two/main.tf
+++ b/terraform/phase-two/main.tf
@@ -1,0 +1,24 @@
+resource "aws_ecs_task_definition" "c19-courts-dashboard-td" {
+  family = "c19-courts-dashboard-td"
+  requires_compatibilities = ["FARGATE"]
+  network_mode = "awsvpc"
+  cpu = 1024
+  memory = 2048
+  execution_role_arn = "arn:aws:iam::129033205317:role/ecsTaskExecutionRole"
+  container_definitions = jsonencode([
+    {
+        name = "pipeline"
+        image = "129033205317.dkr.ecr.eu-west-2.amazonaws.com/c19-courts-dashboard-service:latest"
+        memory = 128
+        environment = [
+            {name = "ACCESS_KEY", value = var.ACCESS_KEY},
+            {name = "SECRET_ACCESS_KEY", value = var.SECRET_ACCESS_KEY},
+            {name = "RDS_ENDPOINT", value = var.RDS_ENDPOINT},
+            {name = "DB_USERNAME", value = var.DB_USERNAME},
+            {name = "DB_PASSWORD", value = var.DB_PASSWORD},
+            {name = "DB_NAME", value = var.DB_NAME}
+        ]
+    }
+
+  ])
+}

--- a/terraform/phase-two/main.tf
+++ b/terraform/phase-two/main.tf
@@ -8,7 +8,7 @@ resource "aws_ecs_task_definition" "c19-courts-dashboard-td" {
   container_definitions = jsonencode([
     {
         name = "pipeline"
-        image = "129033205317.dkr.ecr.eu-west-2.amazonaws.com/c19-courts-dashboard-service:latest"
+        image = var.DASHBOARD_IMAGE_URI
         memory = 128
         environment = [
             {name = "ACCESS_KEY", value = var.ACCESS_KEY},

--- a/terraform/phase-two/variables.tf
+++ b/terraform/phase-two/variables.tf
@@ -41,7 +41,7 @@ variable "SUBNET_IDS" {
 
 variable "DASHBOARD_IMAGE_URI" {
   description = "URI for the dashboard image"
-  type        = list(string)
+  type        = string
 }
 
 variable "RDS_ENDPOINT" {

--- a/terraform/phase-two/variables.tf
+++ b/terraform/phase-two/variables.tf
@@ -38,3 +38,13 @@ variable "SUBNET_IDS" {
   description = "List of subnet IDs for the DB subnet group"
   type        = list(string)
 }
+
+variable "DASHBOARD_IMAGE_URI" {
+  description = "URI for the dashboard image"
+  type        = list(string)
+}
+
+variable "RDS_ENDPOINT" {
+  description = "Endpoint of our RDS instance"
+  type        = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -41,7 +41,7 @@ variable "SUBNET_IDS" {
 
 variable "DASHBOARD_IMAGE_URI" {
   description = "URI for the dashboard image"
-  type        = list(string)
+  type        = string
 }
 
 variable "RDS_ENDPOINT" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,3 +38,13 @@ variable "SUBNET_IDS" {
   description = "List of subnet IDs for the DB subnet group"
   type        = list(string)
 }
+
+variable "DASHBOARD_IMAGE_URI" {
+  description = "URI for the dashboard image"
+  type        = list(string)
+}
+
+variable "RDS_ENDPOINT" {
+  description = "Endpoint of our RDS instance"
+  type        = string
+}


### PR DESCRIPTION
## Related Issue
#63 

## Description
Terraformed the ECS task definition for our dashboard. As it is, the endpoint of the RDS created in phase one needs to be added in `terraform.tfvars` as I couldn't find a way to grab it from a different module - there has to be a way for sure, I tried a couple of things but left it as is for now so we could move forward. 

Closes #63 .

## Requested Reviewers
Anyone available.

## Additional Information
**Make sure to add these two new variables to your `terraform.tfvars`:**
```
DASHBOARD_IMAGE_URI = "your_dashboard_image_uri"
RDS_ENDPOINT = "your_rds_endpoint"
```
(I'll share the actual values on our Slack channel)