### PR TITLE
Fix use of NAMESPACE in .xpath() call

### DIFF
--- a/pipeline/parse_xml.py
+++ b/pipeline/parse_xml.py
@@ -73,7 +73,8 @@ def get_headings(root: "etree._ElementTree") -> list["etree._Element"]:
 
     # We need to remove any <toc> (Table of Contents) tags since
     # this will lead to duplicates and may mess with text extraction
-    toc_elements = root.xpath("//n:toc", namespaces={"n": NAMESPACE})
+    # NAMESPACE[1:-1] is used to remove the {} brackets
+    toc_elements = root.xpath("//n:toc", namespaces={"n": NAMESPACE[1:-1]})
     for toc in toc_elements:
         toc.getparent().remove(toc)
 

--- a/pipeline/parse_xml.py
+++ b/pipeline/parse_xml.py
@@ -74,7 +74,10 @@ def get_headings(root: "etree._ElementTree") -> list["etree._Element"]:
     # We need to remove any <toc> (Table of Contents) tags since
     # this will lead to duplicates and may mess with text extraction
     # NAMESPACE[1:-1] is used to remove the {} brackets
-    toc_elements = root.xpath("//n:toc", namespaces={"n": NAMESPACE[1:-1]})
+    toc_elements = root.xpath(
+        "//n:toc",
+        namespaces={"n": NAMESPACE.strip("{}")}
+    )
     for toc in toc_elements:
         toc.getparent().remove(toc)
 


### PR DESCRIPTION
## Related Issue
Closes #87 

## Description
This PR fixes a small issue where a call to `.xpath()` incorrectly uses the NAMESPACE global, which has `{}` brackets. The fix here is to simply substring `NAMESPACE` so the brackets are cutoff.

## Requested Reviewers
@nicanor-jay (has worked on the script before) @riaz1751 (has reviewed and is familiar with the script)

## Additional Information
N/A
