### PR TITLE
(Extract) Write an extract script to download the XML files of case laws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ terraform.tfstate.backup
 *.json
 *.xml
 *.csv
+
+#coverage
+*.coverage

--- a/case_fetcher/README.md
+++ b/case_fetcher/README.md
@@ -1,0 +1,151 @@
+# UK Caselaw XML Fetcher
+
+A Python utility to fetch recent legal case entries from the UK National Archives Caselaw website's Atom feed, extract links to the Akoma Ntoso XML files, and optionally download them to a local directory.
+
+The script connects to the Caselaw Atom feed, parses the entries, and fetches the corresponding full XML documents for storage or further processing.
+
+---
+
+## Features
+
+* Fetches case entries from the official National Archives Caselaw Atom feed.
+* Extracts the Akoma Ntoso XML link for each case.
+* Supports fetching a custom number of cases per page.
+* Safely downloads XML files, using a slugified case title as the filename.
+* Includes a utility function (`slugify`) for creating safe, 100-character-limited filenames.
+* Comprehensive test suite included using `pytest` and `responses` for mocking HTTP requests.
+
+---
+
+## Installation
+
+### Prerequisites
+
+* Python 3.9 or higher
+* `pip` (Python package manager)
+
+### Setup
+
+1. Clone or download this repository (or place the files in a project directory).
+2. Create a virtual environment (recommended):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+```
+
+3. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Usage
+
+### Running the Fetcher
+
+The script fetches the case feed, loads the XMLs into memory, and optionally saves them to a local folder named `xml_cases`.
+
+```bash
+python case_fetcher.py [options]
+```
+
+### Options
+
+| Argument     | Type | Default | Description                                            |
+| ------------ | ---- | ------- | ------------------------------------------------------ |
+| `--per-page` | int  | 10      | Number of cases to fetch from the Atom feed.           |
+| `--download` | flag | N/A     | If set, the fetched XMLs will be saved to `xml_cases`. |
+
+### Examples
+
+1. Fetch 10 cases into memory (default):
+
+```bash
+python case_fetcher.py
+```
+
+*Output will show how many XMLs were loaded, but files will not be saved.*
+
+2. Fetch 25 cases and save XML files:
+
+```bash
+python case_fetcher.py --per-page 25 --download
+```
+
+*XML files will be saved in the `xml_cases` directory.*
+
+---
+
+## Output Directory
+
+By default, files are saved to the relative directory `xml_cases`.
+
+```
+.
+└── xml_cases/
+    ├── Sample_Case_v_Another_Case__2024__UKSC_1.xml
+    └── Test_Case__2024__EWCA_100.xml
+```
+
+---
+
+## Running Tests
+
+The test suite uses `pytest` and `responses` to mock all external HTTP calls, ensuring tests are fast and reliable.
+
+* Run the complete test suite:
+
+```bash
+pytest test_case_fetcher.py -v
+```
+---
+
+## Project Structure
+
+```
+.
+├── case_fetcher.py            # Main fetching and downloading logic
+├── test_case_fetcher.py       # Comprehensive test suite (using pytest and responses)
+├── requirements.txt           # Python dependencies (requests, pytest, etc.)
+└── README.md                  # This file
+```
+
+---
+
+## Troubleshooting
+
+### HTTP/Network Errors
+
+The `fetch_feed` and `load_single_xml` functions will raise an exception if a non-200 HTTP status code is received.
+
+* Check your network connection.
+* Verify the `BASE_FEED_URL` in `case_fetcher.py` is correct.
+
+### Filename Issues
+
+The `slugify` function handles special characters and limits filenames to 100 characters to prevent filesystem errors.
+
+```python
+slugify("Case [2024] UKSC/1")  # → "Case_2024_UKSC_1"
+```
+
+### Missing XML Files
+
+Some entries in the Atom feed may not include a link to the Akoma Ntoso XML file. These cases are skipped and a message is printed:
+
+```
+No XML for: No XML Case [2024] EWHC 50 (https://caselaw.nationalarchives.gov.uk/id/ewhc/2024/50)
+```
+
+---
+
+## Support
+
+For issues or questions, please check:
+
+* The `test_case_fetcher.py` file for examples of expected function behavior.
+* The docstrings in `case_fetcher.py` for function details.
+* The dependencies listed in `requirements.txt`.

--- a/case_fetcher/requirements.txt
+++ b/case_fetcher/requirements.txt
@@ -1,0 +1,5 @@
+requests
+pytest
+pytest-mock
+pytest-cov
+responses

--- a/case_fetcher/test_case_fetcher.py
+++ b/case_fetcher/test_case_fetcher.py
@@ -1,0 +1,413 @@
+"""
+Unit tests for the `case_fetcher` module.
+
+This module tests the core functionalities of `case_fetcher`, including:
+- Slugifying case titles
+- Fetching Atom feeds from the UK National Archives
+- Extracting XML links from feed entries
+- Loading single and multiple XML files
+- Downloading XML content to local files
+- The main workflow integration
+
+Uses pytest and responses for mocking HTTP requests.
+"""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+import responses
+import case_fetcher
+
+
+# Sample Atom feed XML for testing
+SAMPLE_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:tna="https://caselaw.nationalarchives.gov.uk">
+    <entry>
+        <title>Sample Case v Another Case [2024] UKSC 1</title>
+        <tna:uri>https://caselaw.nationalarchives.gov.uk/id/uksc/2024/1</tna:uri>
+        <link type="application/akn+xml" href="https://example.com/case1.xml"/>
+    </entry>
+    <entry>
+        <title>Test Case [2024] EWCA 100</title>
+        <tna:uri>https://caselaw.nationalarchives.gov.uk/id/ewca/2024/100</tna:uri>
+        <link type="application/akn+xml" href="https://example.com/case2.xml"/>
+    </entry>
+    <entry>
+        <title>No XML Case [2024] EWHC 50</title>
+        <tna:uri>https://caselaw.nationalarchives.gov.uk/id/ewhc/2024/50</tna:uri>
+    </entry>
+</feed>
+"""
+
+SAMPLE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso>
+    <judgment>Test judgment content</judgment>
+</akomaNtoso>
+"""
+
+
+class TestSlugify:
+    """Tests for the `slugify` function in `case_fetcher`."""
+
+    def test_slugify_basic(self):
+        """Ensure basic text is converted with underscores."""
+        result = case_fetcher.slugify("Simple Text")
+        assert result == "Simple_Text"
+
+    def test_slugify_special_chars(self):
+        """Ensure special characters are removed or replaced."""
+        result = case_fetcher.slugify("Case [2024] UKSC/1")
+        assert result == "Case_2024_UKSC_1"
+
+    def test_slugify_long_text(self):
+        """Ensure slug is truncated to maximum length (100)."""
+        long_text = "A" * 150
+        result = case_fetcher.slugify(long_text)
+        assert len(result) == 100
+
+    def test_slugify_multiple_special_chars(self):
+        """Ensure multiple special characters are correctly handled."""
+        result = case_fetcher.slugify("Test!!!Case???[2024]")
+        assert result == "Test_Case_2024_"
+
+    def test_slugify_preserves_hyphens_underscores(self):
+        """Ensure hyphens and underscores are preserved in slugs."""
+        result = case_fetcher.slugify("Test-Case_Name")
+        assert result == "Test-Case_Name"
+
+
+class TestFetchFeed:
+    """Tests for the `fetch_feed` function."""
+
+    @responses.activate
+    def test_fetch_feed_success(self):
+        """Test successful retrieval of Atom feed."""
+        responses.add(
+            responses.GET,
+            f"{case_fetcher.BASE_FEED_URL}?per_page=10",
+            body=SAMPLE_FEED,
+            status=200
+        )
+
+        feed = case_fetcher.fetch_feed(per_page=10)
+        assert feed is not None
+        assert feed.tag.endswith("feed")
+
+    @responses.activate
+    def test_fetch_feed_custom_per_page(self):
+        """Test fetching feed with a custom `per_page` parameter."""
+        responses.add(
+            responses.GET,
+            f"{case_fetcher.BASE_FEED_URL}?per_page=25",
+            body=SAMPLE_FEED,
+            status=200
+        )
+
+        feed = case_fetcher.fetch_feed(per_page=25)
+        assert feed is not None
+
+    @responses.activate
+    def test_fetch_feed_http_error(self):
+        """Test feed fetching when server returns an HTTP error."""
+        responses.add(
+            responses.GET,
+            f"{case_fetcher.BASE_FEED_URL}?per_page=10",
+            status=404
+        )
+
+        with pytest.raises(Exception):
+            case_fetcher.fetch_feed(per_page=10)
+
+
+class TestGetXmlEntries:
+    """Tests for the `get_xml_entries` function."""
+
+    def test_get_xml_entries_all_fields(self):
+        """Ensure all expected fields are extracted from feed entries."""
+        feed = ET.fromstring(SAMPLE_FEED)
+        entries = case_fetcher.get_xml_entries(feed)
+
+        assert len(entries) == 3
+        assert entries[0][0] == "Sample Case v Another Case [2024] UKSC 1"
+        assert entries[0][1] == "https://caselaw.nationalarchives.gov.uk/id/uksc/2024/1"
+        assert entries[0][2] == "https://example.com/case1.xml"
+
+    def test_get_xml_entries_missing_xml_link(self):
+        """Ensure entries without XML links return `None` for href."""
+        feed = ET.fromstring(SAMPLE_FEED)
+        entries = case_fetcher.get_xml_entries(feed)
+
+        assert entries[2][2] is None
+
+    def test_get_xml_entries_empty_feed(self):
+        """Ensure empty feeds return an empty list."""
+        empty_feed = """<?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:tna="https://caselaw.nationalarchives.gov.uk">
+        </feed>
+        """
+        feed = ET.fromstring(empty_feed)
+        entries = case_fetcher.get_xml_entries(feed)
+
+        assert len(entries) == 0
+
+
+class TestLoadSingleXml:
+    """Tests for the `load_single_xml` function."""
+
+    @responses.activate
+    def test_load_single_xml_success(self):
+        """Ensure a single XML file is correctly loaded into a dictionary."""
+        responses.add(
+            responses.GET,
+            "https://example.com/case1.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+
+        entry = ("Sample Case", "uri", "https://example.com/case1.xml")
+        xml_dict = {}
+
+        case_fetcher.load_single_xml(entry, xml_dict)
+
+        assert "Sample_Case" in xml_dict
+        assert xml_dict["Sample_Case"] == SAMPLE_XML
+
+    @responses.activate
+    def test_load_single_xml_http_error(self, capsys):
+        """Ensure HTTP errors are handled gracefully and logged."""
+        responses.add(
+            responses.GET,
+            "https://example.com/case1.xml",
+            status=500
+        )
+
+        entry = ("Sample Case", "uri", "https://example.com/case1.xml")
+        xml_dict = {}
+
+        case_fetcher.load_single_xml(entry, xml_dict)
+
+        captured = capsys.readouterr()
+        assert "Failed to load" in captured.out
+        assert "Sample_Case" not in xml_dict
+
+    def test_load_single_xml_no_href(self, capsys):
+        """Ensure entries with no XML link are logged and skipped."""
+        entry = ("Sample Case", "uri", None)
+        xml_dict = {}
+
+        case_fetcher.load_single_xml(entry, xml_dict)
+
+        captured = capsys.readouterr()
+        assert "No XML for" in captured.out
+        assert len(xml_dict) == 0
+
+
+class TestLoadAllXml:
+    """Tests for the `load_all_xml` function."""
+
+    @responses.activate
+    def test_load_all_xml_multiple_entries(self):
+        """Ensure multiple XML files are loaded correctly."""
+        responses.add(
+            responses.GET,
+            "https://example.com/case1.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case2.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+
+        entries = [
+            ("Case One", "uri1", "https://example.com/case1.xml"),
+            ("Case Two", "uri2", "https://example.com/case2.xml")
+        ]
+
+        xml_dict = case_fetcher.load_all_xml(entries)
+
+        assert len(xml_dict) == 2
+        assert "Case_One" in xml_dict
+        assert "Case_Two" in xml_dict
+
+    @responses.activate
+    def test_load_all_xml_mixed_success_failure(self):
+        """Ensure failed XML loads are skipped, successful ones stored."""
+        responses.add(
+            responses.GET,
+            "https://example.com/case1.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case2.xml",
+            status=404
+        )
+
+        entries = [
+            ("Case One", "uri1", "https://example.com/case1.xml"),
+            ("Case Two", "uri2", "https://example.com/case2.xml")
+        ]
+
+        xml_dict = case_fetcher.load_all_xml(entries)
+
+        assert len(xml_dict) == 1
+        assert "Case_One" in xml_dict
+
+
+class TestDownloadFromDict:
+    """Tests for the `download_from_dict` function."""
+
+    def test_download_from_dict_success(self, tmp_path, monkeypatch):
+        """Ensure XML dictionary is correctly saved to disk."""
+        monkeypatch.setattr(case_fetcher, "out_dir", tmp_path)
+
+        xml_dict = {
+            "test_case": SAMPLE_XML,
+            "another_case": SAMPLE_XML
+        }
+
+        case_fetcher.download_from_dict(xml_dict)
+
+        assert (tmp_path / "test_case.xml").exists()
+        assert (tmp_path / "another_case.xml").exists()
+        assert (tmp_path / "test_case.xml").read_text() == SAMPLE_XML
+
+    def test_download_from_dict_write_error(self, tmp_path, monkeypatch, capsys):
+        """Ensure write errors are logged but do not crash execution."""
+        monkeypatch.setattr(case_fetcher, "out_dir", tmp_path)
+
+        xml_dict = {"test_case": SAMPLE_XML}
+
+        with patch.object(Path, 'write_text', side_effect=IOError("Write error")):
+            case_fetcher.download_from_dict(xml_dict)
+
+        captured = capsys.readouterr()
+        assert "Failed to save" in captured.out
+
+    def test_download_from_dict_empty_dict(self, tmp_path, monkeypatch):
+        """Ensure empty dictionary results in no files written."""
+        monkeypatch.setattr(case_fetcher, "out_dir", tmp_path)
+
+        xml_dict = {}
+        case_fetcher.download_from_dict(xml_dict)
+
+        assert len(list(tmp_path.iterdir())) == 0
+
+
+class TestMain:
+    """Integration tests for the `main` function."""
+
+    @responses.activate
+    def test_main_default_args(self, monkeypatch, tmp_path, capsys):
+        """Test main workflow with default arguments (no download)."""
+        monkeypatch.setattr(case_fetcher, "out_dir", tmp_path)
+        monkeypatch.setattr('sys.argv', ['case_fetcher.py'])
+
+        responses.add(
+            responses.GET,
+            f"{case_fetcher.BASE_FEED_URL}?per_page=10",
+            body=SAMPLE_FEED,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case1.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case2.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+
+        case_fetcher.main()
+
+        captured = capsys.readouterr()
+        assert "Loaded" in captured.out
+        assert "2 XMLs" in captured.out
+        assert not (tmp_path / "Sample_Case_v_Another_Case__2024__UKSC_1.xml").exists()
+
+    @responses.activate
+    def test_main_with_download_flag(self, monkeypatch, tmp_path):
+        """Test main workflow with --download flag (files saved)."""
+        monkeypatch.setattr(case_fetcher, "out_dir", tmp_path)
+        monkeypatch.setattr('sys.argv', ['case_fetcher.py', '--download'])
+
+        responses.add(
+            responses.GET,
+            f"{case_fetcher.BASE_FEED_URL}?per_page=10",
+            body=SAMPLE_FEED,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case1.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case2.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+
+        case_fetcher.main()
+
+        xml_files = list(tmp_path.glob("*.xml"))
+        assert len(xml_files) == 2
+
+    @responses.activate
+    def test_main_custom_per_page(self, monkeypatch, tmp_path):
+        """Test main workflow with custom --per-page argument."""
+        monkeypatch.setattr(case_fetcher, "out_dir", tmp_path)
+        monkeypatch.setattr('sys.argv', ['case_fetcher.py', '--per-page', '25'])
+
+        responses.add(
+            responses.GET,
+            f"{case_fetcher.BASE_FEED_URL}?per_page=25",
+            body=SAMPLE_FEED,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case1.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+        responses.add(
+            responses.GET,
+            "https://example.com/case2.xml",
+            body=SAMPLE_XML,
+            status=200
+        )
+
+        case_fetcher.main()
+
+        assert len(responses.calls) >= 1
+        assert "per_page=25" in responses.calls[0].request.url
+
+
+class TestConstants:
+    """Tests for module-level constants in `case_fetcher`."""
+
+    def test_base_feed_url(self):
+        """Ensure BASE_FEED_URL is correctly defined."""
+        assert case_fetcher.BASE_FEED_URL == "https://caselaw.nationalarchives.gov.uk/atom.xml"
+
+    def test_namespaces(self):
+        """Ensure XML namespaces dictionary contains expected entries."""
+        assert "atom" in case_fetcher.NAMESPACES
+        assert "tna" in case_fetcher.NAMESPACES
+        assert case_fetcher.NAMESPACES["atom"] == "http://www.w3.org/2005/Atom"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/xml_download/xml_download.py
+++ b/xml_download/xml_download.py
@@ -1,0 +1,81 @@
+import requests
+import xml.etree.ElementTree as ET
+from pathlib import Path
+import re
+from typing import List, Tuple, Optional, Dict
+import argparse
+
+BASE_FEED_URL = "https://caselaw.nationalarchives.gov.uk/atom.xml"
+NAMESPACES = {
+    "atom": "http://www.w3.org/2005/Atom",
+    "tna": "https://caselaw.nationalarchives.gov.uk"
+}
+
+out_dir = Path("xml_cases")
+out_dir.mkdir(exist_ok=True)
+
+
+def slugify(text: str) -> str:
+    """Make a safe filename from a string (max length 100 chars)."""
+    return re.sub(r'[^a-zA-Z0-9_-]+', '_', text)[:100]
+
+
+def fetch_feed(per_page: int = 10) -> ET.Element:
+    """Fetch the Atom feed with the specified batch size."""
+    url = f"{BASE_FEED_URL}?per_page={per_page}"
+    r = requests.get(url)
+    r.raise_for_status()
+    return ET.fromstring(r.content)
+
+
+def get_xml_entries(feed: ET.Element) -> List[Tuple[str, str, Optional[str]]]:
+    """
+    Extract entries from the Atom feed.
+    Returns a list of (title, uri, href-to-xml-or-None).
+    """
+    entries = []
+    for entry in feed.findall("atom:entry", NAMESPACES):
+        title = entry.find("atom:title", NAMESPACES).text
+        uri = entry.find("tna:uri", NAMESPACES).text
+        xml_link = entry.find('atom:link[@type="application/akn+xml"]', NAMESPACES)
+        href = xml_link.attrib["href"] if xml_link is not None else None
+        entries.append((title, uri, href))
+    return entries
+
+
+def load_single_xml(entry: Tuple[str, str, Optional[str]], xml_dict: Dict[str, str]) -> None:
+    """
+    Fetch XML for a single entry and store in xml_dict.
+    Key = slugified title, Value = raw XML string.
+    """
+    pass
+
+
+def load_all_xml(entries: List[Tuple[str, str, Optional[str]]]) -> Dict[str, str]:
+    """Load XMLs for all entries into a dictionary."""
+    pass
+
+
+def download_from_dict(xml_dict: Dict[str, str]) -> None:
+    """Write XMLs from xml_dict to disk."""
+    pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch National Archives court XMLs.")
+    parser.add_argument("--per-page", type=int, default=10, help="Number of cases to fetch (default 10).")
+    parser.add_argument("--download", action="store_true", help="Save XMLs to disk as files.")
+    args = parser.parse_args()
+
+    feed = fetch_feed(per_page=args.per_page)
+    entries = get_xml_entries(feed)
+
+    xml_strings = load_all_xml(entries)  # always in memory
+    print(f"Loaded {len(xml_strings)} XMLs into memory")
+
+    if args.download:
+        download_from_dict(xml_strings)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Related Issue
#82 

## Description
This PR introduces the UK Caselaw XML Fetcher, a new utility script (case_fetcher.py) designed to automate the extraction and download of legal case data from the UK National Archives' Caselaw service.

Key Features Implemented:
- Atom Feed Consumption: Connects to the Caselaw Atom feed to discover recent case entries. {uri}
- XML Link Extraction: Parses feed entries to find the Akoma Ntoso XML download link. {href}
- Fetching: Supports fetching a configurable number of cases using the --per-page argument.
- Safe File Handling: Includes a slugify utility to create safe, concise filenames for the downloaded XMLs. - can be changed to neutral citation if needed
- Optional Download: Uses the --download flag to optionally save the XML files to a dedicated xml_cases directory.

Testing: Includes a full test suite (test_case_fetcher.py) using pytest and responses to ensure all fetching, parsing, and downloading logic is robust and reliable.

## Requested Reviewers
ANYBODY

## Additional Information
uses the requests library for all network communication and xml.etree.ElementTree for XML parsing. Dependencies need to be installed via the updated requirements.txt.
