### PR TITLE
Fix: handle multiple appointment date formats

### DIFF
--- a/judge_scraping/judge_scraping.py
+++ b/judge_scraping/judge_scraping.py
@@ -8,6 +8,7 @@ import json
 from datetime import datetime
 from typing import List, Dict, Optional
 from playwright.sync_api import sync_playwright
+import re
 
 # Judicial titles (longest first to avoid partial matches)
 TITLES = [
@@ -33,9 +34,25 @@ def parse_date(text: str) -> Optional[str]:
     if not text:
         return None
     text = text.strip()
+
+    # Regex to detect simple dd-mm-yy, dd/mm/yyyy etc.
+    match = re.search(r"\b\d{2}[-/\.]\d{2}[-/\.]\d{2,4}\b", text)
+    if match:
+        raw_date = match.group(0)
+        formats = [
+            "%d-%m-%y", "%d-%m-%Y",
+            "%d/%m/%y", "%d/%m/%Y",
+            "%d.%m.%y", "%d.%m.%Y",
+        ]
+        for fmt in formats:
+            try:
+                return datetime.strptime(raw_date, fmt).strftime("%Y-%m-%d")
+            except ValueError:
+                continue
+
+    # Fallback to full month names, etc.
     formats = [
         "%d %B %Y", "%d %b %Y",
-        "%d/%m/%Y", "%d-%m-%Y",
         "%Y-%m-%d", "%B %Y", "%b %Y",
     ]
     for fmt in formats:
@@ -72,23 +89,18 @@ def parse_name(full: str) -> Dict[str, Optional[str]]:
         return result
 
     # Detect surname prefixes (e.g. "van der", "de la", "von der")
-    # Check from longest to shortest to avoid partial matches
     surname_start_idx = None
     for prefix in sorted(SURNAME_PREFIXES, key=len, reverse=True):
         prefix_parts = prefix.split()
-        # Slide a window of same length as prefix_parts over the name parts
         for i in range(len(parts) - len(prefix_parts)):
             if " ".join(parts[i:i+len(prefix_parts)]).lower() == prefix:
-                # Found surname prefix (this marks where last_name begins)
                 surname_start_idx = i
                 break
         if surname_start_idx is not None:
             break
 
     if surname_start_idx is not None:
-        # We found a prefix; everything from here is the surname
         if surname_start_idx == 0:
-            # Prefix is at the start, assume entire name is surname
             result["last_name"] = " ".join(parts[surname_start_idx:])
         else:
             result["first_name"] = parts[0]
@@ -96,7 +108,6 @@ def parse_name(full: str) -> Dict[str, Optional[str]]:
                 result["middle_name"] = " ".join(parts[1:surname_start_idx])
             result["last_name"] = " ".join(parts[surname_start_idx:])
     else:
-        # Standard parsing (no surname prefix found)
         if len(parts) == 2:
             result["first_name"], result["last_name"] = parts
         else:
@@ -118,20 +129,16 @@ def scrape_page(page, url: str) -> List[Dict]:
     judges = []
     page.goto(url, wait_until="domcontentloaded", timeout=20000)
 
-    # Find all <table> elements on the page
     for table in page.locator("table").all():
-        # Within each table, get all rows in the <tbody>
         for row in table.locator("tbody tr").all():
-            # Extract text from each <td> cell in the row
             cells = [c.inner_text().strip() for c in row.locator("td").all()]
             if not any(cells):
                 continue
 
             full_name = cells[0]
             if not looks_like_judge(full_name):
-                continue  # skip non-judge entries
+                continue
 
-            # Look for a date value in later cells
             date_val = next((parse_date(c) for c in cells[1:] if parse_date(c)), None)
             parsed = parse_name(full_name)
             judges.append({
@@ -149,9 +156,9 @@ def scrape_page(page, url: str) -> List[Dict]:
 def extract_titles(judges: List[Dict]) -> List[Dict]:
     """Extract unique titles from judges and create title records."""
     seen_titles = {judge["title"] for judge in judges if judge.get("title")}
-    sorted_titles = sorted(seen_titles)  # alphabetical consistency
-    return [{"title_id": idx, "title_name": title} for idx, \
-            title in enumerate(sorted_titles, start=1)]
+    sorted_titles = sorted(seen_titles)
+    return [{"title_id": idx, "title_name": title}
+            for idx, title in enumerate(sorted_titles, start=1)]
 
 
 def add_title_ids(judges: List[Dict], titles: List[Dict]) -> None:
@@ -175,10 +182,8 @@ def main():
         page = browser.new_page()
         page.goto(base_url, wait_until="domcontentloaded", timeout=20000)
 
-        # Collect sublinks (all list-of-members pages)
         links = [a.get_attribute("href") for a in page.locator('a[href*="list-of-members"]').all()]
-        links = [f"https://www.judiciary.uk{l}" \
-                 if l and l.startswith("/") else l for l in links if l]
+        links = [f"https://www.judiciary.uk{l}" if l and l.startswith("/") else l for l in links if l]
 
         if links:
             for link in links:
@@ -188,16 +193,13 @@ def main():
 
         browser.close()
 
-    # Extract and normalise titles
     titles = extract_titles(all_judges)
     add_title_ids(all_judges, titles)
 
-    # Save titles
     with open("titles_data.json", "w", encoding="utf-8") as f:
         json.dump(titles, f, indent=2, ensure_ascii=False)
     print(f"Extracted {len(titles)} unique titles -> titles_data.json")
 
-    # Save judges
     with open("judges_data.json", "w", encoding="utf-8") as f:
         json.dump(all_judges, f, indent=2, ensure_ascii=False)
     print(f"Extracted {len(all_judges)} judges -> judges_data.json")


### PR DESCRIPTION
## Related Issue
Closes #101 

## Description
Rapid fix done on a huddle - 
Discovered a bug that caused some date formats for judge_data.json to not be parsed correctly - this has been addressed by adding it to the regex which now correctly parses over 600 previously null dates

Added back in comments because i'd pushed my local copy of this script rather than production that had comments 🫡

## Requested Reviewers
Anybody that wants to check through

## Additional Information
Now only 83 judges without dates - this is consistent with the web page
