### PR TITLE
Add judge names to metadata extraction

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -44,7 +44,7 @@ from metadata_xml import get_metadata
 ...
 ```
 
-`get_metadata()` takes a filepath to an `.xml` file, and returns a dictionary containing metadata about that file.
+`get_metadata()` takes a raw XML file string, and returns a dictionary containing metadata about that file.
 
 Specifically, the data returned is:
 - `title` (`str`): The title of the hearing.
@@ -52,6 +52,7 @@ Specifically, the data returned is:
 - `verdict_date` (`datetime`): The date when judgement was handed down.
 - `court` (`str`): The name of the court where the hearing took place.
 - `url` (`str`): A URL to the hearing transcript page.
+- `judges` (`list[str]`): A list containing the names of judges who sat the hearing.
 
 > **NOTE**:
 >
@@ -70,6 +71,6 @@ $ python metadata_xml.py -f <filename.xml>
 The script accepts two CLI arguments:
 
 - `-f`: path to XML file to extract from; mandatory.
-- `-o`: a flag to indicate if metadata should be output as JSON.
+- `-o`: output data to JSON file.
 
 You can also call the script with `-h` to view a summary of the arguments listed above.

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -59,12 +59,16 @@ def get_case_name(meta: "etree._Element") -> str:
     return name_element.get("value")
 
 
-def get_court_name(meta: "etree._Element") -> str:
+def get_court_name(meta: "etree._Element") -> str | None:
     """Returns the name of the institution/court where the hearing took place."""
     xpath = "//n:TLCOrganization"
     org_element = meta.xpath(xpath, namespaces=NS_MAPPING)
     # tna (The National Archives) is also listed as an org, so we need to filter it
-    org_element = list(filter(lambda e: e.get("eId") != "tna", org_element))[0]
+    org_element = list(filter(lambda e: e.get("eId") != "tna", org_element))
+    if org_element:
+        org_element = org_element[0]
+    else:
+        return None
     return org_element.get("showAs")
 
 

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -80,9 +80,9 @@ def get_judges(root: etree._Element) -> list[str] | None:
     return judges if judges else None
 
 
-def get_metadata(filename: str) -> dict:
+def get_metadata(xml_string: str) -> dict:
     """
-    Extracts metadata from `filename` and returns it as a dictionary.
+    Extracts metadata from `xml_str` and returns it as a dictionary.
     Structure of the returned dictionary:
 
     `title` (`str`): The title of the hearing.
@@ -92,14 +92,14 @@ def get_metadata(filename: str) -> dict:
     `url` (`str`): A URL to the hearing transcript page.
     `judges` (`list[str]`): List of judges who sat the hearing.
     """
-    if not filename.endswith(".xml"):
-        raise ValueError("filename must be a .xml file")
+    if not isinstance(xml_string, str):
+        raise TypeError("xml_string must be a str type")
 
-    root = etree.parse(filename)
+    root = etree.fromstring(xml_string.encode("utf-8"))
     try:
         meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     except IndexError as e:
-        raise KeyError(f"{filename} has no meta element") from e
+        raise KeyError("xml_string has no meta element") from e
 
     metadata = {
         "title": get_case_name(meta),

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -118,8 +118,8 @@ def output_metadata(filename: str, metadata: dict) -> None:
     if not filename.endswith(".json"):
         raise ValueError("filename must be a .json file")
 
-    with open(filename, "w", encoding="utf-8") as f:
-        json.dump(metadata, f, indent=4)
+    with open(filename, "w", encoding="utf-8") as json_file:
+        json.dump(metadata, json_file, indent=4)
 
 
 def set_up_args() -> argparse.Namespace:
@@ -142,8 +142,8 @@ if __name__ == "__main__":
     data = get_metadata(xml_raw_string)
 
     # datetime can't be serialized, so convert into string
-    date_str = datetime.strftime(data["verdict_date"], "%Y-%m-%d")
-    data["verdict_date"] = date_str
+    date = datetime.strftime(data["verdict_date"], "%Y-%m-%d")
+    data["verdict_date"] = date
 
     print(json.dumps(data, indent=4))
     if args.output:

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -117,10 +117,6 @@ def output_metadata(filename: str, metadata: dict) -> None:
     if not filename.endswith(".json"):
         raise ValueError("filename must be a .json file")
 
-    # datetime can't be serialized, so convert into string
-    date_str = datetime.strftime(metadata["verdict_date"], "%Y-%m-%d")
-    metadata["verdict_date"] = date_str
-
     with open(filename, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=4)
 
@@ -133,18 +129,21 @@ def set_up_args() -> argparse.Namespace:
         type=str, required=True,
         help="XML file to process")
     parser.add_argument(
-        "-o", "--output", action="store_true",
+        "-o", "--output",
         help="If given, will output a JSON file of the same name")
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = set_up_args()
-    data = get_metadata(args.file)
+    with open(args.file, encoding="utf-8") as f:
+        xml_raw_string = f.read()
+    data = get_metadata(xml_raw_string)
+
+    # datetime can't be serialized, so convert into string
+    date_str = datetime.strftime(data["verdict_date"], "%Y-%m-%d")
+    data["verdict_date"] = date_str
+
+    print(json.dumps(data, indent=4))
     if args.output:
-        # change filename extension
-        output_file = args.file.replace(".xml", ".json")
-        # get base of path
-        base_start = output_file.rfind('/')+1
-        output_file = output_file[base_start:] if base_start >= 0 else output_file
-        output_metadata(output_file, data)
+        output_metadata(args.output, data)

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -106,7 +106,8 @@ def get_metadata(xml_string: str) -> dict:
         "citation": get_case_citation(meta),
         "verdict_date": get_case_judgement_date(meta),
         "court": get_court_name(meta),
-        "url": get_case_url(meta)
+        "url": get_case_url(meta),
+        "judges": get_judges(meta)
     }
 
     return metadata

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -68,6 +68,14 @@ def get_court_name(meta: "etree._Element") -> str:
     return org_element.get("showAs")
 
 
+def get_judges(root: etree._Element) -> list[str] | None:
+    """Returns a list of the judges who sat the hearing."""
+    people = root.xpath("//n:TLCPerson", namespaces=NS_MAPPING)
+    judges = [person.get("showAs")
+              for person in people if person.get("href") != ""]
+    return judges if judges else None
+
+
 def get_metadata(filename: str) -> dict:
     """
     Extracts metadata from `filename` and returns it as a dictionary.
@@ -78,6 +86,7 @@ def get_metadata(filename: str) -> dict:
     `verdict_date` (`datetime`): The date when judgement was handed down.
     `court` (`str`): The name of the court where the hearing took place.
     `url` (`str`): A URL to the hearing transcript page.
+    `judges` (`list[str]`): List of judges who sat the hearing.
     """
     if not filename.endswith(".xml"):
         raise ValueError("filename must be a .xml file")

--- a/pipeline/metadata_xml.py
+++ b/pipeline/metadata_xml.py
@@ -13,7 +13,7 @@ NS_MAPPING = {
 }
 
 
-def get_case_url(meta: "etree._Element") -> str:
+def get_case_url(meta: "etree._Element") -> str | None:
     """Returns case hearing URL from metadata."""
     xpath = "//n:FRBRExpression//n:FRBRthis"
     url_element = meta.xpath(xpath, namespaces=NS_MAPPING)
@@ -25,7 +25,7 @@ def get_case_url(meta: "etree._Element") -> str:
     return url_element.get("value")
 
 
-def get_case_judgement_date(meta: "etree._Element") -> datetime:
+def get_case_judgement_date(meta: "etree._Element") -> datetime | None:
     """Returns the date when judgement was handed down from metadata."""
     xpath = "//n:FRBRExpression//n:FRBRdate"
     date_element = meta.xpath(xpath, namespaces=NS_MAPPING)
@@ -37,7 +37,7 @@ def get_case_judgement_date(meta: "etree._Element") -> datetime:
     return datetime.strptime(date_str, "%Y-%m-%d")
 
 
-def get_case_citation(meta: "etree._Element") -> str:
+def get_case_citation(meta: "etree._Element") -> str | None:
     """Returns the neutral citation, which can be used as a unique identifier."""
     xpath = "//nuk:cite"
     cite_element = meta.xpath(xpath, namespaces=NS_MAPPING)
@@ -48,7 +48,7 @@ def get_case_citation(meta: "etree._Element") -> str:
     return cite_element.text
 
 
-def get_case_name(meta: "etree._Element") -> str:
+def get_case_name(meta: "etree._Element") -> str | None:
     """Returns the title given to the case hearing."""
     xpath = "//n:FRBRWork//n:FRBRname"
     name_element = meta.xpath(xpath, namespaces=NS_MAPPING)

--- a/pipeline/test_metadata_xml.py
+++ b/pipeline/test_metadata_xml.py
@@ -19,6 +19,7 @@ from metadata_xml import (
 
 
 def test_get_case_name_correct_type(xml_metadata):
+    """Check case name is a string."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     name = get_case_name(meta)
@@ -26,6 +27,7 @@ def test_get_case_name_correct_type(xml_metadata):
 
 
 def test_get_case_name_correct_name(xml_metadata):
+    """Check case name is correct."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     name = get_case_name(meta)
@@ -34,6 +36,7 @@ def test_get_case_name_correct_name(xml_metadata):
 
 
 def test_get_case_citation_correct_type(xml_metadata):
+    """Check citation is a string."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     citation = get_case_citation(meta)
@@ -41,6 +44,7 @@ def test_get_case_citation_correct_type(xml_metadata):
 
 
 def test_get_case_citation_correct_citation(xml_metadata):
+    """Check citation is correct."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     citation = get_case_citation(meta)
@@ -49,6 +53,7 @@ def test_get_case_citation_correct_citation(xml_metadata):
 
 
 def test_get_case_judgement_date_correct_type(xml_metadata):
+    """Check judgement date is datetime."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     date = get_case_judgement_date(meta)
@@ -56,6 +61,7 @@ def test_get_case_judgement_date_correct_type(xml_metadata):
 
 
 def test_get_case_judgement_date_correct_citation(xml_metadata):
+    """Check judgement date is correct."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     date = get_case_judgement_date(meta)
@@ -64,6 +70,7 @@ def test_get_case_judgement_date_correct_citation(xml_metadata):
 
 
 def test_get_court_name_correct_type(xml_metadata):
+    """Test court name is string."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     court_name = get_court_name(meta)
@@ -71,6 +78,7 @@ def test_get_court_name_correct_type(xml_metadata):
 
 
 def test_get_court_name_correct_name(xml_metadata):
+    """Test court name is correct."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     court_name = get_court_name(meta)
@@ -79,13 +87,15 @@ def test_get_court_name_correct_name(xml_metadata):
 
 
 def test_get_case_url_correct_type(xml_metadata):
+    """Test url is string."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     url = get_case_url(meta)
     assert isinstance(url, str)
 
 
-def test_get_case_url_correct_name(xml_metadata):
+def test_get_case_url_is_correct(xml_metadata):
+    """Test url is correct."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     url = get_case_url(meta)
@@ -94,6 +104,7 @@ def test_get_case_url_correct_name(xml_metadata):
 
 
 def test_get_judges_correct_type(xml_metadata):
+    """Test judges is a list."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     judges = get_judges(meta)
@@ -101,6 +112,7 @@ def test_get_judges_correct_type(xml_metadata):
 
 
 def test_get_judges_correct_elements_type(xml_metadata):
+    """Test judges elements are all strings."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     judges = get_judges(meta)
@@ -108,6 +120,7 @@ def test_get_judges_correct_elements_type(xml_metadata):
 
 
 def test_get_judges_correct_name(xml_metadata):
+    """Test names in judges is correct."""
     root = etree.fromstring(xml_metadata)
     meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
     judges = get_judges(meta)
@@ -117,17 +130,20 @@ def test_get_judges_correct_name(xml_metadata):
 
 
 def test_get_metadata_rejects_bad_xml_string_type():
+    """Test get metadata rejects bad xml_string."""
     with pytest.raises(TypeError) as exc_info:
         get_metadata(101)
         assert "xml_string must be a str type" in exc_info.value
 
 
 def test_get_metadata_returns_dict(xml_metadata):
+    """Test get metadata returns a dictionary."""
     metadata = get_metadata(xml_metadata.decode("utf-8"))
     assert isinstance(metadata, dict)
 
 
 def test_get_metadata_dict_has_correct_keys(xml_metadata):
+    """Test get metadata dictionary has correct keys."""
     metadata = get_metadata(xml_metadata.decode("utf-8"))
     assert list(metadata.keys()) == ['title', 'citation', 'verdict_date',
                                      'court', 'url', 'judges']

--- a/pipeline/test_metadata_xml.py
+++ b/pipeline/test_metadata_xml.py
@@ -116,20 +116,18 @@ def test_get_judges_correct_name(xml_metadata):
     assert judges == real_judges
 
 
-def test_get_metadata_rejects_bad_filename():
-    with pytest.raises(ValueError) as exc_info:
-        get_metadata("bad_file.csv")
-        assert "filename must be a .xml file" in exc_info.value
+def test_get_metadata_rejects_bad_xml_string_type():
+    with pytest.raises(TypeError) as exc_info:
+        get_metadata(101)
+        assert "xml_string must be a str type" in exc_info.value
 
 
 def test_get_metadata_returns_dict(xml_metadata):
-    etree.parse = Mock(return_value=etree.fromstring(xml_metadata))
-    metadata = get_metadata("dummy.xml")
+    metadata = get_metadata(xml_metadata.decode("utf-8"))
     assert isinstance(metadata, dict)
 
 
 def test_get_metadata_dict_has_correct_keys(xml_metadata):
-    etree.parse = Mock(return_value=etree.fromstring(xml_metadata))
-    metadata = get_metadata("dummy.xml")
-    assert list(metadata.keys()) == ['title', 'citation',
-                                     'verdict_date', 'court', 'url']
+    metadata = get_metadata(xml_metadata.decode("utf-8"))
+    assert list(metadata.keys()) == ['title', 'citation', 'verdict_date',
+                                     'court', 'url', 'judges']

--- a/pipeline/test_metadata_xml.py
+++ b/pipeline/test_metadata_xml.py
@@ -13,6 +13,7 @@ from metadata_xml import (
     get_case_judgement_date,
     get_court_name,
     get_case_url,
+    get_judges,
     get_metadata
 )
 
@@ -90,6 +91,29 @@ def test_get_case_url_correct_name(xml_metadata):
     url = get_case_url(meta)
     real_url = "https://caselaw.nationalarchives.gov.uk/ukpc/2025/47"
     assert url == real_url
+
+
+def test_get_judges_correct_type(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    judges = get_judges(meta)
+    assert isinstance(judges, list)
+
+
+def test_get_judges_correct_elements_type(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    judges = get_judges(meta)
+    assert all(isinstance(judge, str) for judge in judges)
+
+
+def test_get_judges_correct_name(xml_metadata):
+    root = etree.fromstring(xml_metadata)
+    meta = root.xpath("//n:meta", namespaces=NS_MAPPING)[0]
+    judges = get_judges(meta)
+    real_judges = ['Lord Briggs', 'Lord Sales',
+                   'Lord Hamblen', 'Lord Burrows', 'Lord Richards']
+    assert judges == real_judges
 
 
 def test_get_metadata_rejects_bad_filename():


### PR DESCRIPTION
## Related Issue
Closes #109 & closes #111 

## Description
This PR updates `metadata_xml.py` and its tests for two purposes.

The first is to add a `judges` key in the returned metadata dictionary; `judges` will be a `list[str]` containing the names of judges who sat the hearing, or `None` if no judge metadata was found.

The second is to change the interface of the script to expect XML strings rather than paths to `.xml` files. The purpose of this is to be more consistent with the outputs of other files in the repository, such as `case_fetcher.py`.

## Requested Reviewers
@nicanor-jay (familiar with the script) @riaz1751 @lenaverse (will be using the script output in the load stage)

## Additional Information
A future consideration regarding the extracted judge names is to use functionality from `judge_scraping,py` to normalise the extracted metadata, as currently the formatting of the names is unpredictable.
