### PR TITLE
Update gpt prompt, schema & headers

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -64,5 +64,4 @@ INSERT INTO judgement
 (judgement_favour)
 VALUES
 ('Defendant'),
-('Plaintiff'),
-('Undisclosed');
+('Plaintiff');

--- a/gpt/summary.py
+++ b/gpt/summary.py
@@ -14,10 +14,9 @@ def get_extract_headings_prompt() -> str:
     return """You are a UK legal data extraction assistant.
     You will be given a python-style list of headers from a court transcript.
     Return a list of headers from the input, where the content of the headers will help deduce the following:
-    Summary: [a concise description of what the hearing was about, maximum 1000 characters]
-    Ruling: [which party the court ruled in favour of. ONLY ONLY ONLY give a one word answer out of the options: Plaintiff, Defendant, Undisclosed]
-    Only give Undisclosed if the court hearing explicitly state so. Otherwise, it is your job to analyse the hearing, and decide whether the verdict was
-    in the favour or Plaintiff or Defendant.
+    Summary: [a concise description of what the hearing was about, MAXIMUM MAXIMUM 1000 characters]
+    Ruling: [which party the court ruled in favour of. ONLY ONLY ONLY give a one word answer out of the options: Plaintiff, Defendant]
+    It is your job to analyse the hearing, and decide whether the verdict was in the favour or Plaintiff or Defendant.
     Anomalies: [whether anything irregular happened in the context of a normal court hearing. If no anomalies found, reply with 'None Found']
     Give the list in the following format: "'heading1','heading2','heading3'"
     """
@@ -29,10 +28,9 @@ def get_summarise_prompt() -> str:
     You will be given a python-style dictionary where headings will be mapped to their corresponding content for a single transcript.
     Redact all personal information about the parties involved.
     Your task is to carefully extract and return the following fields:
-    Summary: [a concise description of what the hearing was about, maximum 1000 characters]
-    Ruling: [which party the court ruled in favour of. ONLY ONLY ONLY give a one word answer out of the options: Plaintiff, Defendant, Undisclosed]
-    Only give Undisclosed if the court hearing explicitly state so. Otherwise, it is your job to analyse the hearing, and decide whether the verdict was
-    in the favour or Plaintiff or Defendant.
+    Summary: [a concise description of what the hearing was about, MAXIMUM MAXIMUM 1000 characters]
+    Ruling: [which party the court ruled in favour of. ONLY ONLY ONLY give a one word answer out of the options: Plaintiff, Defendant]
+    It is your job to analyse the hearing, and decide whether the verdict was in the favour or Plaintiff or Defendant.
     Anomalies: [whether anything irregular happened in the context of a normal court hearing. If no anomalies found, reply with 'None Found']
     Return your output strictly in this JSON format:
     {
@@ -177,7 +175,7 @@ def extract_meaningful_headers(transcripts: list[dict], filename: str) -> dict:
     for transcript in transcripts:
         for citation, headers_info in transcript.items():
             query_message = create_query_messages(
-                get_extract_headings_prompt(), str(list[headers_info.keys()]))
+                get_extract_headings_prompt(), str(list(headers_info.keys())))
             request = create_batch_request(
                 query_message, citation)
             insert_request(request, filename)

--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -238,7 +238,7 @@ def insert_into_hearing(conn: connection, hearing: dict, metadata: dict) -> None
         RETURNING hearing_id;
         """
         cur.execute(query, (judgement_id, court_id, citation,
-                    hearing_title, hearing_date, description, hearing_url, anomaly))
+                    hearing_title, hearing_date, description[:1000], hearing_url, anomaly[:1000]))
         hearing_id = cur.fetchone()['hearing_id']
         logging.info("Inserting hearing: %s...", citation)
         conn.commit()


### PR DESCRIPTION
## Related Issue
Closes #125 

## Description
This PR closes #125 by updating `schema.sql` to not include 'Undisclosed', and also removes all reference to that judgement favour in our GPT prompts.

## Requested Reviewers
Anyone

## Additional Information
This isn't the full implementation yet, as we are still reliant on @cameronriley0's case insensitive title cleaning.
