### PR TITLE
Add dummy judge

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -57,11 +57,3 @@ CREATE TABLE judge_hearing (
     judge_id BIGINT REFERENCES judge (judge_id),
     hearing_id BIGINT REFERENCES hearing (hearing_id)
 );
-
--- Seed judgement table
-
-INSERT INTO judgement
-(judgement_favour)
-VALUES
-('Defendant'),
-('Plaintiff');

--- a/database/seed_db.sql
+++ b/database/seed_db.sql
@@ -5,3 +5,10 @@ INSERT INTO judgement
 VALUES
 ('Defendant'),
 ('Plaintiff');
+
+-- Seed placeholder judge
+
+INSERT INTO judge
+    (title_id, first_name, middle_name, last_name, appointment_date)
+VALUES
+    (NULL, 'X', 'Y', 'Unknown', TO_TIMESTAMP('0001-01-01', 'YYYY-MM-DD'))

--- a/database/seed_db.sql
+++ b/database/seed_db.sql
@@ -1,0 +1,7 @@
+-- Seed judgement table
+
+INSERT INTO judgement
+(judgement_favour)
+VALUES
+('Defendant'),
+('Plaintiff');

--- a/database/seed_db.sql
+++ b/database/seed_db.sql
@@ -1,10 +1,10 @@
 -- Seed judgement table
 
 INSERT INTO judgement
-(judgement_favour)
+    (judgement_favour)
 VALUES
-('Defendant'),
-('Plaintiff');
+    ('Defendant'),
+    ('Plaintiff');
 
 -- Seed placeholder judge
 

--- a/database/setup_reset.sh
+++ b/database/setup_reset.sh
@@ -2,3 +2,4 @@ source ../.env
 export PGPASSWORD=$DB_PASSWORD
 
 psql -h $DB_HOST -U $DB_USERNAME -p $DB_PORT -d $DB_NAME -f schema.sql
+psql -h $DB_HOST -U $DB_USERNAME -p $DB_PORT -d $DB_NAME -f seed_db.sql

--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -196,7 +196,9 @@ def insert_into_hearing(conn: connection, hearing: dict, metadata: dict) -> None
     """ Inserts a new row in the hearing table. """
     if not metadata.get('judges'):
         # Skip if judges is None
-        logging.info('Skipping %s - No Judges', metadata.get("citation"))
+        logging.info('No Judges in %s - defaulting to unknown.',
+                     metadata.get("citation"))
+        metadata['judges'] = ["Unknown"]
         return
 
     if not get_judgement_id(conn, hearing.get('ruling')):

--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -199,7 +199,6 @@ def insert_into_hearing(conn: connection, hearing: dict, metadata: dict) -> None
         logging.info('No Judges in %s - defaulting to unknown.',
                      metadata.get("citation"))
         metadata['judges'] = ["Unknown"]
-        return
 
     if not get_judgement_id(conn, hearing.get('ruling')):
         logging.info('Skipping. No conclusive judgement found.')


### PR DESCRIPTION
## Related Issue
Closes #127 

## Description
This PR adds a placeholder judge to the seed data (which is now in its own dedicated file called `seed_db.sql`). It also amends the behaviour of `insert_into_hearing()` to fallback to this placeholder judge when no metadata about judges is received.

## Requested Reviewers
@nicanor-jay @lenaverse 

## Additional Information
N/A
