### PR TITLE
Improve XML extraction

### DIFF
--- a/xml_extraction/get_unique_xml.py
+++ b/xml_extraction/get_unique_xml.py
@@ -48,8 +48,8 @@ def is_xml_unique(xml_string: str, conn: connection) -> bool:
     return result is None
 
 
-def get_unique_xmls(conn: connection, number: int) -> list[str]:
-    """Fetches the last `number` XML transcripts, and returns only the uniques"""
+def get_unique_xmls(conn: connection, number: int = 20) -> list[str]:
+    """Fetches the last `number` (default 20) XML transcripts, and returns only the uniques"""
     xml_strings = get_xml_strings(per_page=number)
     return [string for string in xml_strings if is_xml_unique(string, conn)]
 

--- a/xml_extraction/get_unique_xml.py
+++ b/xml_extraction/get_unique_xml.py
@@ -48,9 +48,9 @@ def is_xml_unique(xml_string: str, conn: connection) -> bool:
     return result is None
 
 
-def get_unique_xmls(conn: connection) -> list[str]:
-    """Fetches the last 20 XML transcripts, and returns only the uniques"""
-    xml_strings = get_xml_strings(50)
+def get_unique_xmls(conn: connection, number: int) -> list[str]:
+    """Fetches the last `number` XML transcripts, and returns only the uniques"""
+    xml_strings = get_xml_strings(per_page=number)
     return [string for string in xml_strings if is_xml_unique(string, conn)]
 
 

--- a/xml_extraction/metadata_xml.py
+++ b/xml_extraction/metadata_xml.py
@@ -79,7 +79,7 @@ def get_judges(root: etree._Element) -> list[str] | None:
     people = root.xpath("//n:TLCPerson", namespaces=NS_MAPPING)
     judges = [person.get("showAs")
               for person in people if person.get("href") != ""]
-    judges = [pattern.sub('', judge).strip() for judge in judges]
+    judges = [pattern.sub('', judge).strip().title() for judge in judges]
     return judges if judges else None
 
 

--- a/xml_extraction/parse_xml.py
+++ b/xml_extraction/parse_xml.py
@@ -178,24 +178,21 @@ def get_label_text_dict(xml_string: str) -> dict[str, str] | None:
         text_pairings["DOC_START"] = raw_text
 
     for i, heading in enumerate(headings):
-        if i >= len(headings)-1:
-            # skip the last element as there is
-            # no next heading to read up to
-            continue
         header_text = "".join(heading.itertext()).strip()
         # sometimes run-off text tends to get lumped in with headings
         # we can remove this by cutting the text to the first newline
         newline_idx = header_text.find('\n')
         header_text = header_text[:newline_idx] if newline_idx > 0 else header_text
+        if i >= len(headings)-1:
+            # raw text of last element is a special case
+            # should have end_element as None
+            raw_text = get_text_between_elements(
+                root, start_element=headings[-1])
+            raw_text = whitespace_pattern.sub(' ', raw_text).strip()
+            text_pairings[header_text] = raw_text
+            continue
         raw_text = get_text_between_elements(root, headings[0], headings[1])
         raw_text = whitespace_pattern.sub(' ', raw_text).strip()
         text_pairings[header_text] = raw_text
-
-    # Get from last heading til end
-    # labeled as 'DOC_END'
-    raw_text = get_text_between_elements(root, start_element=headings[-1])
-    raw_text = whitespace_pattern.sub(' ', raw_text).strip()
-    if raw_text != "":
-        text_pairings["DOC_END"] = raw_text
 
     return text_pairings

--- a/xml_extraction/parse_xml.py
+++ b/xml_extraction/parse_xml.py
@@ -178,6 +178,10 @@ def get_label_text_dict(xml_string: str) -> dict[str, str] | None:
             # no next heading to read up to
             continue
         header_text = "".join(heading.itertext()).strip()
+        # sometimes run-off text tends to get lumped in with headings
+        # we can remove this by cutting the text to the first newline
+        newline_idx = header_text.find('\n')
+        header_text = header_text[:newline_idx] if newline_idx > 0 else header_text
         raw_text = get_text_between_elements(root, headings[0], headings[1])
         text_pairings[header_text] = raw_text
 

--- a/xml_extraction/parse_xml.py
+++ b/xml_extraction/parse_xml.py
@@ -165,10 +165,15 @@ def get_label_text_dict(xml_string: str) -> dict[str, str] | None:
     if not headings:
         return None
 
+    # this regex will find any excessive whitespace
+    # which will be used to clean up the raw text
+    whitespace_pattern = re.compile(r"(?:[\n\t]+ *)+")
+
     text_pairings = {}
     # Get text up to first heading
     # labeled as 'DOC_START'
     raw_text = get_text_between_elements(root, end_element=headings[0])
+    raw_text = whitespace_pattern.sub(' ', raw_text).strip()
     if raw_text != "":
         text_pairings["DOC_START"] = raw_text
 
@@ -183,11 +188,13 @@ def get_label_text_dict(xml_string: str) -> dict[str, str] | None:
         newline_idx = header_text.find('\n')
         header_text = header_text[:newline_idx] if newline_idx > 0 else header_text
         raw_text = get_text_between_elements(root, headings[0], headings[1])
+        raw_text = whitespace_pattern.sub(' ', raw_text).strip()
         text_pairings[header_text] = raw_text
 
     # Get from last heading til end
     # labeled as 'DOC_END'
     raw_text = get_text_between_elements(root, start_element=headings[-1])
+    raw_text = whitespace_pattern.sub(' ', raw_text).strip()
     if raw_text != "":
         text_pairings["DOC_END"] = raw_text
 

--- a/xml_extraction/parse_xml.py
+++ b/xml_extraction/parse_xml.py
@@ -189,7 +189,8 @@ def get_label_text_dict(xml_string: str) -> dict[str, str] | None:
             raw_text = get_text_between_elements(
                 root, start_element=headings[-1])
             raw_text = whitespace_pattern.sub(' ', raw_text).strip()
-            text_pairings[header_text] = raw_text
+            if raw_text != "":
+                text_pairings[header_text] = raw_text
             continue
         raw_text = get_text_between_elements(root, headings[0], headings[1])
         raw_text = whitespace_pattern.sub(' ', raw_text).strip()

--- a/xml_extraction/parse_xml.py
+++ b/xml_extraction/parse_xml.py
@@ -149,17 +149,17 @@ def get_text_between_elements(
     return text
 
 
-def get_label_text_dict(xml_str: str) -> dict[str, str] | None:
+def get_label_text_dict(xml_string: str) -> dict[str, str] | None:
     """
     Returns a dictionary containing {label: key} pairs
-    corresponding to a heading in `xml_str` and the
-    raw text in that section. `xml_str` must be an XML str.
+    corresponding to a heading in `xml_string` and the
+    raw text in that section. `xml_string` must be an XML str.
     """
 
-    if not isinstance(xml_str, str):
+    if not isinstance(xml_string, str):
         raise ValueError("filename must be a str")
 
-    root = etree.fromstring(xml_str.encode())
+    root = etree.fromstring(xml_string.encode())
     headings = get_headings(root)
 
     if not headings:

--- a/xml_extraction/parse_xml.py
+++ b/xml_extraction/parse_xml.py
@@ -157,7 +157,7 @@ def get_label_text_dict(xml_string: str) -> dict[str, str] | None:
     """
 
     if not isinstance(xml_string, str):
-        raise ValueError("filename must be a str")
+        raise TypeError("xml_string must be a str")
 
     root = etree.fromstring(xml_string.encode())
     headings = get_headings(root)

--- a/xml_extraction/test_parse_xml.py
+++ b/xml_extraction/test_parse_xml.py
@@ -101,14 +101,15 @@ def test_get_label_text_dict_correct_length(xml_natural_file):
 
 def test_get_label_text_dict_correct_keys(xml_natural_file):
     label_dict = get_label_text_dict(xml_natural_file.decode())
+    print(label_dict.keys())
     assert any("The facts" in k for k in label_dict.keys())
-    assert any("DOC_END" in k for k in label_dict.keys())
+    assert any("The legal framework:" in k for k in label_dict.keys())
 
 
-# def test_get_label_text_dict_rejects_bad_filename():
-#     with pytest.raises(ValueError) as exc_info:
-#         get_label_text_dict("bad_file.csv")
-#         assert "filename must be an .xml file" in exc_info.value
+def test_get_label_text_dict_rejects_bad_xml_string():
+    with pytest.raises(TypeError) as exc_info:
+        get_label_text_dict(101)
+        assert "xml_string must be a str" in exc_info.value
 
 
 def test_get_label_text_dict_no_headings_is_none(xml_no_headings):


### PR DESCRIPTION
## Related Issue
Closes #136 

## Description
This PR makes several miscellaneous improvements to the XML extraction scripts, with the overall aim of improving the data outputted by the ETL pipeline. The PR touches: `get_unique_xml.py`, `metadata_xml.py` and `parse_xml.py`.

Specifically, the improvements are:
- Parameterising `get_unique_xmls()` to modify how many XMLs to return.
- Returning judge name metadata in Title Case.
- Cutting extracted headings at the first newline character when there is one.
- Cleaning raw text returned in the {label: text} dictionary by the parser by removing excess embedded whitespace.
- Changing `DOC_END` to the name of the final heading (this should _hopefully_ improve summaries by GPT).

## Requested Reviewers
Anyone

## Additional Information
N/A
