### PR TITLE
Add etl dockerfile

### DIFF
--- a/gpt/requirements.txt
+++ b/gpt/requirements.txt
@@ -1,0 +1,6 @@
+openai
+pylint
+pytest
+pytest-mock
+pytest-cov
+python-dotenv

--- a/pipeline/build_push_dockerfile.sh
+++ b/pipeline/build_push_dockerfile.sh
@@ -1,0 +1,9 @@
+source .env
+
+aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+
+docker buildx build . -t $PIPELINE_NAME:latest --platform "Linux/amd64" --provenance=false -f ./pipeline/dockerfile
+
+docker tag $PIPELINE_NAME:latest $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$PIPELINE_ECR_NAME:latest
+
+docker push $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$PIPELINE_ECR_NAME:latest

--- a/pipeline/dockerfile
+++ b/pipeline/dockerfile
@@ -1,0 +1,64 @@
+FROM public.ecr.aws/lambda/python:3.13
+
+# Set lambda root as working directory
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+# Grab requirement files
+COPY ./case_fetcher/requirements.txt ./case_fetcher/
+COPY ./gpt/requirements.txt ./gpt/
+COPY ./judge_scraping/requirements.txt ./judge_scraping/
+COPY ./xml_extraction/requirements.txt ./xml_extraction/
+COPY ./pipeline/requirements.txt ./pipeline/
+
+# Install all requirements
+RUN dnf install -y findutils
+RUN find . -type f -name "requirements.txt" | sed -e 's/^/-r /' | xargs pip install
+
+# Install playwright chromium
+RUN playwright install chromium
+RUN dnf install -y alsa-lib \
+at-spi2-atk \
+at-spi2-core \
+atk \
+bash \
+cairo \
+cups-libs \
+dbus-libs \
+expat \
+flac-libs \
+gdk-pixbuf2 \
+glib2 \
+glibc \
+gtk3 \
+libX11 \
+libXcomposite \
+libXdamage \
+libXext \
+libXfixes \
+libXrandr \
+libXtst \
+libcanberra-gtk3 \
+libdrm \
+libgcc \
+libstdc++ \
+libxcb \
+libxkbcommon \
+libxshmfence \
+libxslt \
+mesa-libgbm \
+nspr \
+nss \
+nss-util \
+pango \
+policycoreutils \
+policycoreutils-python-utils \
+zlib
+
+# Copy everything else
+COPY ./case_fetcher ./case_fetcher/
+COPY ./gpt ./gpt/
+COPY ./judge_scraping ./judge_scraping/
+COPY ./xml_extraction ./xml_extraction/
+COPY ./pipeline ./pipeline/
+
+CMD [ "pipeline.etl.handler" ]

--- a/pipeline/dockerfile
+++ b/pipeline/dockerfile
@@ -16,6 +16,10 @@ RUN find . -type f -name "requirements.txt" | sed -e 's/^/-r /' | xargs pip inst
 
 # Install playwright chromium
 RUN playwright install chromium
+
+# This is needed due to playwright's dependencies
+# It installs a bunch of shared library files that
+# are missing from the image OS (Rocky Linux)
 RUN dnf install -y alsa-lib \
 at-spi2-atk \
 at-spi2-core \

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv
 pytest
 pylint
-psycopg2
+psycopg2-binary


### PR DESCRIPTION
## Related Issue
Closes #37 and closes #39 .

## Description
This PR sets up the ETL pipeline, dockerises it and also adds a shell script to build the docker image and push it to the ECR repository with one command.

## Requested Reviewers
@nicanor-jay @cameronriley0 

## Additional Information
It is already explained in the dockerfile comments, but we've had to install a bunch of extra libraries for playwright to work on a lambda.
