### PR TITLE
Remove openai api key from github actions

### DIFF
--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -51,13 +51,9 @@ jobs:
           find . -type f -name "requirements.txt" | sed -e 's/^/-r /' | xargs pip install
 
       - name: Run the tests
-        env: 
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           pytest .
 
       - name: Run coverage
-        env: 
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           pytest --cov-fail-under=60

--- a/pipeline/gpt/README.md
+++ b/pipeline/gpt/README.md
@@ -28,11 +28,11 @@ This script is intended to be imported as a module by other scripts (it has no "
 from summary import extract_meaningful_headers, summarise
 ```
 
-The `extract_meaningful_headers` method will take a *list of dicts, may change once webscraping functionality implemented* and return a `{identifier:[headers]}` dictionary where:
+The `extract_meaningful_headers` method will take a list of dicts and return a `{identifier:[headers]}` dictionary where:
 - `identifier` is the unique identifier for a specific court transcript
 - `[headers]` is a list of all the meaningful headers from the transcript
 
-The `summarise` method will take a *list of dicts, may change once webscraping functionality implemented* and return a `{identifier: {transcript_summary}}` dictionary where:
+The `summarise` method will take a list of dicts and return a `{identifier: {transcript_summary}}` dictionary where:
 - `identifier` is the unique identifier for a specific court transcript
 - `{transcript_summary}` is a dictionary storing the summary data which will be in the form:
 ```

--- a/pipeline/gpt/summary.py
+++ b/pipeline/gpt/summary.py
@@ -157,7 +157,7 @@ def get_batch_meaningful_headers(batch_id: str) -> dict:
 
     # show token usage for requests in the batch
     token_summary, total_batch_tokens = get_batch_token_usage(batch_id)
-    logging.info(f"Token usage per request:")
+    logging.info("Token usage per request:")
     for item in token_summary:
         logging.info(f"{item['custom_id']} Request Token Usage: {item}")
     logging.info(f"Total batch tokens used: {total_batch_tokens}")
@@ -186,7 +186,7 @@ def get_batch_summaries(batch_id: str) -> dict:
     
     # show token usage for requests in the batch
     token_summary, total_batch_tokens = get_batch_token_usage(batch_id)
-    logging.info(f"Token usage per request:")
+    logging.info("Token usage per request:")
     for item in token_summary:
         logging.info(f"{item['custom_id']} Request Token Usage: {item}")
     logging.info(f"Total batch tokens used: {total_batch_tokens}")


### PR DESCRIPTION
## Related Issue
Closes #184 

## Description
This PR removes the OpenAI API key as an environment variable from Github actions yaml file as it is not used.

## Requested Reviewers
Anyone Available

## Additional Information
Small improvements were also made to the `README` and `summary.py` to fix grammatical issues.