### PR TITLE
Rename ENV VAR key names

### DIFF
--- a/email/aws_utils.py
+++ b/email/aws_utils.py
@@ -42,7 +42,7 @@ def get_boto3_connection():
     load_dotenv()
     session = boto3.Session(
         aws_access_key_id=ENV['ACCESS_KEY'],
-        aws_secret_access_key=ENV['SECRET_KEY'],
+        aws_secret_access_key=ENV['SECRET_ACCESS_KEY'],
         region_name=ENV['REGION']
     )
 

--- a/email/send_email.py
+++ b/email/send_email.py
@@ -14,7 +14,7 @@ def send_html_email(subscriber_list: list, email_html: str):
     """Sends the daily email to the subscribers."""
     ses_client = boto3.client("ses",
                               aws_access_key_id=ENV['ACCESS_KEY'],
-                              aws_secret_access_key=ENV['SECRET_KEY'],
+                              aws_secret_access_key=ENV['SECRET_ACCESS_KEY'],
                               region_name=ENV['REGION'])
     CHARSET = "UTF-8"
 

--- a/email/verify_email.py
+++ b/email/verify_email.py
@@ -11,7 +11,7 @@ def verify_email_identity():
     """Sends an email to the given Email Address to verify for SES email sending."""
     ses_client = boto3.client("ses",
                               aws_access_key_id=ENV['ACCESS_KEY'],
-                              aws_secret_access_key=ENV['SECRET_KEY'],
+                              aws_secret_access_key=ENV['SECRET_ACCESS_KEY'],
                               region_name=ENV['REGION'])
     response = ses_client.verify_email_identity(
         EmailAddress=ENV['ORIGIN_EMAIL']


### PR DESCRIPTION
HOTFIX
This fix renames `SECRET_KEY` to `SECRET_ACCESS_KEY`.

Currently these two key names aren't aligned. This PR fixes that.