### PR TITLE
Fix: catch hearings without citations

### DIFF
--- a/pipeline/etl.py
+++ b/pipeline/etl.py
@@ -57,6 +57,9 @@ def parse_transcripts(unique_xmls: list[str]) -> list[dict]:
         if headings_dict is None:
             continue
         citation = metadata_xml.get_metadata(xml)["citation"]
+        if citation is None:
+            # Exclude XML with missing citation
+            continue
         transcripts.append({citation: headings_dict})
     return transcripts
 
@@ -122,6 +125,8 @@ def run_etl(number_of_transcripts: int = 20) -> None:
         conn, number=number_of_transcripts)
     logging.info("%s unique transcripts found", len(unique_xmls))
     metadatas = extract_and_parse_xml(unique_xmls)
+    # Filter XMLs without citation from metadata list
+    metadatas = [data for data in metadatas if data["citation"] is not None]
     transcripts = parse_transcripts(unique_xmls)
     transcripts = extract_meaningful_headers_and_content(
         transcripts, MEANINGFUL_HEADERS_INPUT)


### PR DESCRIPTION
## Related Issue
Hotfix

## Description
Very rarely some hearings will lack a citation, meaning that its `citation` value will be `None`. This, in turn, leads to the `custom_id` field in `summary.py` being `null`, which breaks the batching call to the GPT API. This PR changes the ETL code to drop any hearing transcripts which do not have citation metadata; this shouldn't affect the number of hearings too much because, as mentioned before, it is very rare for transcripts to lack citations.

This PR also adds some extra logging to `summary.py` - specifically it logs `batch.message` when a batch fails, which normally contains useful information about why the failure happened.

## Requested Reviewers
@nicanor-jay @riaz1751 

## Additional Information
N/A
